### PR TITLE
feat(token-vesting): add clawback support and secure claim transfer o…

### DIFF
--- a/contracts/token_vesting/src/lib.rs
+++ b/contracts/token_vesting/src/lib.rs
@@ -12,6 +12,7 @@ pub enum DataKey {
     CliffTime,
     EndTime,
     ClaimedAmount,
+    ClawbackAdmin,
 }
 
 #[contract]
@@ -28,6 +29,7 @@ impl TokenVesting {
     /// * `start_ts` - The Unix timestamp when the vesting begins.
     /// * `cliff_ts` - The Unix timestamp before which no tokens can be claimed (cliff period).
     /// * `end_ts` - The Unix timestamp when all tokens will be fully vested.
+    /// * `clawback_admin` - The address authorized to reclaim unvested tokens.
     pub fn initialize(
         env: Env,
         recipient: Address,
@@ -36,6 +38,7 @@ impl TokenVesting {
         start_ts: u64,
         cliff_ts: u64,
         end_ts: u64,
+        clawback_admin: Address,
     ) {
         if env.storage().instance().has(&DataKey::Init) {
             panic!("Contract already initialized");
@@ -58,8 +61,9 @@ impl TokenVesting {
         env.storage().instance().set(&DataKey::CliffTime, &cliff_ts);
         env.storage().instance().set(&DataKey::EndTime, &end_ts);
         env.storage().instance().set(&DataKey::ClaimedAmount, &0i128);
+        env.storage().instance().set(&DataKey::ClawbackAdmin, &clawback_admin);
 
-        log!(&env, "Vesting initialized", recipient, total_amount);
+        log!(&env, "Vesting initialized", recipient, total_amount, clawback_admin);
     }
 
     /// Claims all currently vested tokens for the recipient.
@@ -86,20 +90,48 @@ impl TokenVesting {
 
         let token_addr: Address = env.storage().instance().get(&DataKey::Token).expect("No token registered");
         let token_client = token::Client::new(&env, &token_addr);
-        
-        // Transfer tokens from this contract to the recipient
+
+        // Update state before external token transfer to prevent re-entrancy.
+        env.storage().instance().set(&DataKey::ClaimedAmount, &(claimed + claimable));
         token_client.transfer(&env.current_contract_address(), &recipient, &claimable);
 
-        // Update the claimed amount
-        env.storage().instance().set(&DataKey::ClaimedAmount, &(claimed + claimable));
-
-        // Emit an event for transparency
         env.events().publish(
             (Symbol::new(&env, "vesting_claimed"), recipient),
-            claimable
+            claimable,
         );
 
         claimable
+    }
+
+    /// Reclaims all currently unvested tokens to the authorized clawback admin or destination.
+    ///
+    /// Only the configured clawback admin may call this function.
+    pub fn clawback(env: Env, destination: Address) -> i128 {
+        let admin: Address = env.storage().instance().get(&DataKey::ClawbackAdmin).expect("Not initialized");
+        admin.require_auth();
+
+        let now = env.ledger().timestamp();
+        let total_amount: i128 = env.storage().instance().get(&DataKey::TotalAmount).unwrap_or(0);
+        let vested = Self::vested_amount_at(&env, now);
+        let unvested = total_amount - vested;
+        if unvested <= 0 {
+            return 0;
+        }
+
+        // Freeze future vesting and ensure state reflects reclaimed unvested tokens.
+        env.storage().instance().set(&DataKey::TotalAmount, &vested);
+        env.storage().instance().set(&DataKey::EndTime, &now);
+
+        let token_addr: Address = env.storage().instance().get(&DataKey::Token).expect("No token registered");
+        let token_client = token::Client::new(&env, &token_addr);
+        token_client.transfer(&env.current_contract_address(), &destination, &unvested);
+
+        env.events().publish(
+            (Symbol::new(&env, "vesting_clawed_back"), admin, destination),
+            unvested,
+        );
+
+        unvested
     }
 
     /// Returns the total amount of tokens vested up to the current timestamp.

--- a/contracts/token_vesting/src/test.rs
+++ b/contracts/token_vesting/src/test.rs
@@ -27,13 +27,22 @@ fn test_linear_vesting_flow() {
     let start_ts = 1000;
     let cliff_ts = 1500;
     let end_ts = 2000;
+    let clawback_admin = employer.clone();
     
     // 1. Initial funding: mint tokens to the vesting contract
     token_admin.mint(&contract_id, &total_amount);
     assert_eq!(token.balance(&contract_id), total_amount);
     
     // 2. Initialize the contract
-    client.initialize(&recipient, &token_addr, &total_amount, &start_ts, &cliff_ts, &end_ts);
+    client.initialize(
+        &recipient,
+        &token_addr,
+        &total_amount,
+        &start_ts,
+        &cliff_ts,
+        &end_ts,
+        &clawback_admin,
+    );
 
     // 3. Test before start
     env.ledger().set_timestamp(500);
@@ -94,8 +103,9 @@ fn test_double_initialization() {
     let client = TokenVestingClient::new(&env, &contract_id);
     let addr = Address::generate(&env);
 
-    client.initialize(&addr, &addr, &1000, &100, &100, &200);
-    client.initialize(&addr, &addr, &1000, &100, &100, &200);
+    let clawback_admin = Address::generate(&env);
+    client.initialize(&addr, &addr, &1000, &100, &100, &200, &clawback_admin);
+    client.initialize(&addr, &addr, &1000, &100, &100, &200, &clawback_admin);
 }
 
 #[test]
@@ -108,12 +118,71 @@ fn test_unauthorized_claim() {
     let contract_id = env.register(TokenVesting, ());
     let client = TokenVestingClient::new(&env, &contract_id);
     let token_addr = Address::generate(&env);
+    let clawback_admin = Address::generate(&env);
 
-    client.initialize(&recipient, &token_addr, &1000, &100, &100, &200);
+    client.initialize(&recipient, &token_addr, &1000, &100, &100, &200, &clawback_admin);
     
     // Attacker tries to claim (will fail because mock_all_auths is not called or recipient didn't sign)
-    // Actually, without mock_all_auths, require_auth will fail for any address unless we provide auth.
     client.claim(); 
+}
+
+#[test]
+fn test_clawback_by_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let recipient = Address::generate(&env);
+    let employer = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract_v2(employer.clone()).address();
+    let token_admin = StellarAssetClient::new(&env, &token_addr);
+    let token = TokenClient::new(&env, &token_addr);
+    let contract_id = env.register(TokenVesting, ());
+    let client = TokenVestingClient::new(&env, &contract_id);
+
+    let total_amount = 1_000_000_i128;
+    let start_ts = 100;
+    let cliff_ts = 200;
+    let end_ts = 300;
+    let clawback_admin = employer.clone();
+
+    token_admin.mint(&contract_id, &total_amount);
+    client.initialize(
+        &recipient,
+        &token_addr,
+        &total_amount,
+        &start_ts,
+        &cliff_ts,
+        &end_ts,
+        &clawback_admin,
+    );
+
+    env.ledger().set_timestamp(250);
+    assert_eq!(client.get_vested_amount(), 150_000_i128);
+
+    let reclaim_destination = Address::generate(&env);
+    let reclaimed = client.clawback(&reclaim_destination);
+    assert_eq!(reclaimed, 850_000_i128);
+    assert_eq!(token.balance(&reclaim_destination), 850_000_i128);
+    assert_eq!(client.get_vested_amount(), 150_000_i128);
+    assert_eq!(client.get_claimable_amount(), 150_000_i128);
+}
+
+#[test]
+#[should_panic]
+fn test_unauthorized_clawback() {
+    let env = Env::default();
+    let recipient = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let token_addr = Address::generate(&env);
+    let clawback_admin = Address::generate(&env);
+
+    let contract_id = env.register(TokenVesting, ());
+    let client = TokenVestingClient::new(&env, &contract_id);
+
+    client.initialize(&recipient, &token_addr, &1000, &100, &150, &200, &clawback_admin);
+
+    // Attacker tries to reclaim tokens without admin authorization.
+    client.clawback(&attacker);
 }
 
 #[test]
@@ -123,8 +192,9 @@ fn test_get_info() {
     let contract_id = env.register(TokenVesting, ());
     let client = TokenVestingClient::new(&env, &contract_id);
     let token_addr = Address::generate(&env);
+    let clawback_admin = Address::generate(&env);
 
-    client.initialize(&recipient, &token_addr, &1000, &100, &150, &200);
+    client.initialize(&recipient, &token_addr, &1000, &100, &150, &200, &clawback_admin);
     
     let (addr, total, claimed, start, end) = client.get_info();
     assert_eq!(addr, recipient);


### PR DESCRIPTION
Close #205 

## PR Document

### Title
`feat(token-vesting): add clawback functionality and secure claim order`

### Summary
This PR enhances the `token_vesting` Soroban contract by adding DAO/admin-controlled clawback support, while preserving the existing linear vesting and configurable cliff behavior. It also improves security by updating state before external token transfers during claims.

### What changed
- lib.rs
  - Added `ClawbackAdmin` storage key.
  - Extended `initialize(...)` to accept `clawback_admin`.
  - Added `clawback(destination: Address)` to reclaim currently unvested tokens.
  - Freezes vesting on clawback by updating `TotalAmount` and `EndTime`.
  - Emits `vesting_clawed_back` event.
  - Updated `claim()` ordering to update claimed state before token transfer to reduce reentrancy risk.

- test.rs
  - Updated all tests to use the new initialization signature.
  - Added `test_clawback_by_admin`.
  - Added `test_unauthorized_clawback`.
  - Kept existing linear vesting and claim coverage intact.

### Why
- Implements the required clawback capability for secure token vesting.
- Provides admin-controlled recovery of unvested tokens.
- Ensures vesting logic remains transparent and auditable with events.
- Improves contract security on claim transfers.

### Testing
Run the Soroban contract tests for the vesting contract:

```bash
cd /workspaces/EventHorizon/contracts/token_vesting
cargo test
```

Expected outcome:
- All existing vesting tests still pass.
- New clawback tests pass.
- No diagnostics errors in modified files.

