### PR TITLE
feat(backend): advanced JSONPath filtering for trigger conditions

### DIFF
--- a/backend/__tests__/filterEvaluator.test.js
+++ b/backend/__tests__/filterEvaluator.test.js
@@ -1,0 +1,255 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    passesFilters,
+    evaluateFilter,
+} = require('../src/utils/filterEvaluator');
+
+const sampleEvent = {
+    id: 'evt_123',
+    ledger: 1000,
+    contractId: 'C123',
+    type: 'contract',
+    value: {
+        amount: 500,
+        currency: 'USDC',
+        tags: ['transfer', 'outgoing'],
+        from: 'GABC',
+        to: 'GXYZ',
+    },
+    topics: ['transfer', 'GABC', 'GXYZ'],
+    nested: {
+        level1: {
+            level2: {
+                level3: {
+                    target: 'deep-value',
+                    score: 42,
+                },
+            },
+        },
+    },
+    items: [
+        { name: 'alpha', price: 10, active: true },
+        { name: 'beta', price: 25, active: false },
+        { name: 'gamma', price: 100, active: true },
+    ],
+};
+
+test('passesFilters returns true when filters are empty', () => {
+    assert.equal(passesFilters(sampleEvent, []), true);
+    assert.equal(passesFilters(sampleEvent, undefined), true);
+    assert.equal(passesFilters(sampleEvent, null), true);
+});
+
+test('passesFilters returns false for non-array filters', () => {
+    assert.equal(passesFilters(sampleEvent, { bad: 'shape' }), false);
+});
+
+test('eq operator matches exact value at nested path', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.currency', operator: 'eq', value: 'USDC' }]),
+        true,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.currency', operator: 'eq', value: 'XLM' }]),
+        false,
+    );
+});
+
+test('eq coerces numeric string comparisons', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.amount', operator: 'eq', value: '500' }]),
+        true,
+    );
+});
+
+test('neq operator inverts equality', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.currency', operator: 'neq', value: 'XLM' }]),
+        true,
+    );
+});
+
+test('numeric comparisons work across gt/gte/lt/lte', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.amount', operator: 'gt', value: 100 }]),
+        true,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.amount', operator: 'gte', value: 500 }]),
+        true,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.amount', operator: 'lt', value: 1000 }]),
+        true,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.amount', operator: 'lte', value: 499 }]),
+        false,
+    );
+});
+
+test('contains operator works on arrays, strings, and objects', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.tags', operator: 'contains', value: 'transfer' }]),
+        true,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.currency', operator: 'contains', value: 'USD' }]),
+        true,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value', operator: 'contains', value: 'amount' }]),
+        true,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.tags', operator: 'contains', value: 'missing' }]),
+        false,
+    );
+});
+
+test('in operator checks membership', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [{
+            path: '$.value.currency',
+            operator: 'in',
+            value: ['USDC', 'XLM'],
+        }]),
+        true,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [{
+            path: '$.value.currency',
+            operator: 'in',
+            value: ['XLM'],
+        }]),
+        false,
+    );
+});
+
+test('exists operator detects presence and absence', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.amount', operator: 'exists' }]),
+        true,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.nonexistent', operator: 'exists' }]),
+        false,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [{ path: '$.value.nonexistent', operator: 'exists', value: false }]),
+        true,
+    );
+});
+
+test('evaluates deeply nested paths', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [{
+            path: '$.nested.level1.level2.level3.target',
+            operator: 'eq',
+            value: 'deep-value',
+        }]),
+        true,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [{
+            path: '$.nested.level1.level2.level3.score',
+            operator: 'gt',
+            value: 40,
+        }]),
+        true,
+    );
+});
+
+test('evaluates filters over arrays with JSONPath slice/wildcard', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [{
+            path: '$.items[*].name',
+            operator: 'eq',
+            value: 'gamma',
+        }]),
+        true,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [{
+            path: '$.items[*].price',
+            operator: 'gt',
+            value: 50,
+        }]),
+        true,
+    );
+});
+
+test('evaluates filters over filtered array expressions', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [{
+            path: '$.items[?(@.active==true)].name',
+            operator: 'contains',
+            value: 'alpha',
+        }]),
+        true,
+    );
+});
+
+test('all filters must pass (AND semantics)', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [
+            { path: '$.value.currency', operator: 'eq', value: 'USDC' },
+            { path: '$.value.amount', operator: 'gt', value: 100 },
+        ]),
+        true,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [
+            { path: '$.value.currency', operator: 'eq', value: 'USDC' },
+            { path: '$.value.amount', operator: 'gt', value: 10000 },
+        ]),
+        false,
+    );
+});
+
+test('missing path causes comparison filter to fail', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [{
+            path: '$.nonexistent.field',
+            operator: 'eq',
+            value: 'anything',
+        }]),
+        false,
+    );
+});
+
+test('invalid filter paths fail closed rather than throwing', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [{
+            path: '$..*',
+            operator: 'exists',
+        }]),
+        false,
+    );
+    assert.equal(
+        passesFilters(sampleEvent, [{
+            path: 'not-a-valid-path',
+            operator: 'eq',
+            value: 1,
+        }]),
+        false,
+    );
+});
+
+test('evaluateFilter returns false for malformed filters', () => {
+    assert.equal(evaluateFilter({ path: '$.x', operator: 'weird', value: 1 }, sampleEvent), false);
+    assert.equal(evaluateFilter(null, sampleEvent), false);
+});
+
+test('non-numeric values fail numeric comparisons gracefully', () => {
+    assert.equal(
+        passesFilters(sampleEvent, [{
+            path: '$.value.currency',
+            operator: 'gt',
+            value: 10,
+        }]),
+        false,
+    );
+});

--- a/backend/__tests__/jsonpathValidator.test.js
+++ b/backend/__tests__/jsonpathValidator.test.js
@@ -1,0 +1,130 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    validatePath,
+    validateFilter,
+    validateFilters,
+    MAX_PATH_LENGTH,
+    MAX_FILTERS_PER_TRIGGER,
+} = require('../src/utils/jsonpathValidator');
+
+test('validatePath accepts standard paths', () => {
+    assert.equal(validatePath('$.value.amount').ok, true);
+    assert.equal(validatePath('$.events[0].payload').ok, true);
+    assert.equal(validatePath("$.data['key']").ok, true);
+    assert.equal(validatePath('$..author').ok, true);
+    assert.equal(validatePath('$.items[?(@.price > 10)]').ok, true);
+});
+
+test('validatePath rejects non-string input', () => {
+    assert.equal(validatePath(null).ok, false);
+    assert.equal(validatePath(123).ok, false);
+    assert.equal(validatePath(undefined).ok, false);
+});
+
+test('validatePath rejects empty path', () => {
+    assert.equal(validatePath('').ok, false);
+    assert.equal(validatePath('   ').ok, false);
+});
+
+test('validatePath rejects paths over max length', () => {
+    const longPath = '$.' + 'a'.repeat(MAX_PATH_LENGTH);
+    const result = validatePath(longPath);
+    assert.equal(result.ok, false);
+    assert.match(result.error, /max length/);
+});
+
+test('validatePath requires root $', () => {
+    const result = validatePath('foo.bar');
+    assert.equal(result.ok, false);
+    assert.match(result.error, /must start with \$/);
+});
+
+test('validatePath rejects regex patterns (ReDoS prevention)', () => {
+    const result = validatePath('$.items[?(@.name=/bad/)]');
+    assert.equal(result.ok, false);
+    assert.match(result.error, /Regular expressions|disallowed characters/);
+});
+
+test('validatePath rejects paths with slashes (regex delimiters)', () => {
+    const result = validatePath('$.items[?(@.name =~ /(a+)+/)]');
+    assert.equal(result.ok, false);
+});
+
+test('validatePath rejects recursive wildcard', () => {
+    const result = validatePath('$..*');
+    assert.equal(result.ok, false);
+    assert.match(result.error, /Recursive wildcard/);
+});
+
+test('validatePath rejects eval-like patterns', () => {
+    assert.equal(validatePath('$.foo.eval(bar)').ok, false);
+    assert.equal(validatePath('$.foo.Function(bar)').ok, false);
+    assert.equal(validatePath('$.foo.require(bar)').ok, false);
+    assert.equal(validatePath('$.process.env').ok, false);
+});
+
+test('validatePath rejects unbalanced brackets', () => {
+    assert.equal(validatePath('$.items[0').ok, false);
+    assert.equal(validatePath('$.items0]').ok, false);
+});
+
+test('validatePath rejects unbalanced parentheses', () => {
+    assert.equal(validatePath('$.items[?(@.x > 1]').ok, false);
+});
+
+test('validateFilter accepts valid filter shapes', () => {
+    assert.equal(validateFilter({ path: '$.a', operator: 'eq', value: 1 }).ok, true);
+    assert.equal(validateFilter({ path: '$.a', operator: 'exists' }).ok, true);
+    assert.equal(validateFilter({ path: '$.a', operator: 'in', value: [1, 2] }).ok, true);
+});
+
+test('validateFilter rejects unknown operators', () => {
+    const result = validateFilter({ path: '$.a', operator: 'weird', value: 1 });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /not supported/);
+});
+
+test('validateFilter requires array for "in" operator', () => {
+    const result = validateFilter({ path: '$.a', operator: 'in', value: 'not-an-array' });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /requires an array/);
+});
+
+test('validateFilter requires value for comparison operators', () => {
+    const result = validateFilter({ path: '$.a', operator: 'eq' });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /requires a value/);
+});
+
+test('validateFilters accepts empty/nullish input', () => {
+    assert.equal(validateFilters(undefined).ok, true);
+    assert.equal(validateFilters(null).ok, true);
+    assert.equal(validateFilters([]).ok, true);
+});
+
+test('validateFilters rejects non-array', () => {
+    const result = validateFilters({ not: 'an-array' });
+    assert.equal(result.ok, false);
+});
+
+test('validateFilters enforces max filter count', () => {
+    const many = Array.from({ length: MAX_FILTERS_PER_TRIGGER + 1 }, () => ({
+        path: '$.a',
+        operator: 'exists',
+    }));
+    const result = validateFilters(many);
+    assert.equal(result.ok, false);
+    assert.match(result.error, /too many filters/);
+});
+
+test('validateFilters reports index of failing filter', () => {
+    const filters = [
+        { path: '$.a', operator: 'eq', value: 1 },
+        { path: '$..*', operator: 'exists' },
+    ];
+    const result = validateFilters(filters);
+    assert.equal(result.ok, false);
+    assert.match(result.error, /filters\[1\]/);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "express-rate-limit": "^8.3.1",
     "ioredis": "^5.3.0",
     "joi": "^18.1.1",
+    "jsonpath-plus": "^10.4.0",
     "mongoose": "^8.0.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"

--- a/backend/src/middleware/validation.middleware.js
+++ b/backend/src/middleware/validation.middleware.js
@@ -1,13 +1,40 @@
 const Joi = require('joi');
+const {
+    validateFilters,
+    MAX_FILTERS_PER_TRIGGER,
+} = require('../utils/jsonpathValidator');
+
+const filterSchema = Joi.object({
+    path: Joi.string().trim().required(),
+    operator: Joi.string()
+        .valid('eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'contains', 'in', 'exists')
+        .required(),
+    value: Joi.any(),
+});
+
+const filtersSchema = Joi.array()
+    .items(filterSchema)
+    .max(MAX_FILTERS_PER_TRIGGER)
+    .custom((value, helpers) => {
+        const result = validateFilters(value);
+        if (!result.ok) {
+            return helpers.error('any.invalid', { message: result.error });
+        }
+        return value;
+    }, 'JSONPath security validation')
+    .messages({
+        'any.invalid': '{{#message}}',
+    });
 
 const validationSchemas = {
     triggerCreate: Joi.object({
         contractId: Joi.string().trim().required(),
         eventName: Joi.string().trim().required(),
-        actionType: Joi.string().valid('webhook', 'discord', 'email').default('webhook'),
+        actionType: Joi.string().valid('webhook', 'discord', 'email', 'telegram').default('webhook'),
         actionUrl: Joi.string().trim().uri().required(),
         isActive: Joi.boolean().default(true),
         lastPolledLedger: Joi.number().integer().min(0).default(0),
+        filters: filtersSchema.default([]),
     }),
     authCredentials: Joi.object({
         email: Joi.string().trim().email().required(),

--- a/backend/src/models/trigger.model.js
+++ b/backend/src/models/trigger.model.js
@@ -1,5 +1,33 @@
 const mongoose = require('mongoose');
 
+const FILTER_OPERATORS = [
+    'eq',
+    'neq',
+    'gt',
+    'gte',
+    'lt',
+    'lte',
+    'contains',
+    'in',
+    'exists',
+];
+
+const filterSchema = new mongoose.Schema({
+    path: {
+        type: String,
+        required: true,
+        trim: true,
+    },
+    operator: {
+        type: String,
+        enum: FILTER_OPERATORS,
+        required: true,
+    },
+    value: {
+        type: mongoose.Schema.Types.Mixed,
+    },
+}, { _id: false });
+
 const triggerSchema = new mongoose.Schema({
     contractId: {
         type: String,
@@ -54,8 +82,12 @@ const triggerSchema = new mongoose.Schema({
         type: Map,
         of: String,
         index: true
+    },
+    filters: {
+        type: [filterSchema],
+        default: [],
     }
-}, { 
+}, {
     timestamps: true,
     toJSON: { virtuals: true },
     toObject: { virtuals: true }
@@ -76,4 +108,7 @@ triggerSchema.virtual('healthStatus').get(function() {
     return 'critical';
 });
 
-module.exports = mongoose.model('Trigger', triggerSchema);
+const Trigger = mongoose.model('Trigger', triggerSchema);
+
+module.exports = Trigger;
+module.exports.FILTER_OPERATORS = FILTER_OPERATORS;

--- a/backend/src/utils/filterEvaluator.js
+++ b/backend/src/utils/filterEvaluator.js
@@ -1,0 +1,110 @@
+const { JSONPath } = require('jsonpath-plus');
+const { validateFilter } = require('./jsonpathValidator');
+
+const EVALUATION_TIMEOUT_MS = 50;
+
+function queryPath(path, event) {
+    const start = Date.now();
+    const result = JSONPath({
+        path,
+        json: event,
+        preventEval: true,
+        wrap: true,
+    });
+    const elapsed = Date.now() - start;
+    if (elapsed > EVALUATION_TIMEOUT_MS) {
+        throw new Error(`JSONPath evaluation exceeded ${EVALUATION_TIMEOUT_MS}ms budget`);
+    }
+    return Array.isArray(result) ? result : [result];
+}
+
+function compareNumbers(actual, expected) {
+    const a = Number(actual);
+    const b = Number(expected);
+    if (Number.isNaN(a) || Number.isNaN(b)) return null;
+    return { a, b };
+}
+
+function applyOperator(operator, actual, expected) {
+    switch (operator) {
+        case 'eq':
+            return actual === expected || String(actual) === String(expected);
+        case 'neq':
+            return actual !== expected && String(actual) !== String(expected);
+        case 'gt': {
+            const nums = compareNumbers(actual, expected);
+            return nums ? nums.a > nums.b : false;
+        }
+        case 'gte': {
+            const nums = compareNumbers(actual, expected);
+            return nums ? nums.a >= nums.b : false;
+        }
+        case 'lt': {
+            const nums = compareNumbers(actual, expected);
+            return nums ? nums.a < nums.b : false;
+        }
+        case 'lte': {
+            const nums = compareNumbers(actual, expected);
+            return nums ? nums.a <= nums.b : false;
+        }
+        case 'contains':
+            if (Array.isArray(actual)) {
+                return actual.some((v) => v === expected || String(v) === String(expected));
+            }
+            if (typeof actual === 'string') {
+                return actual.includes(String(expected));
+            }
+            if (actual && typeof actual === 'object') {
+                return Object.prototype.hasOwnProperty.call(actual, expected);
+            }
+            return false;
+        case 'in':
+            if (!Array.isArray(expected)) return false;
+            return expected.some((v) => v === actual || String(v) === String(actual));
+        case 'exists':
+            return actual !== undefined && actual !== null;
+        default:
+            return false;
+    }
+}
+
+function evaluateFilter(filter, event) {
+    const validation = validateFilter(filter);
+    if (!validation.ok) {
+        return false;
+    }
+
+    let matches;
+    try {
+        matches = queryPath(filter.path, event);
+    } catch (err) {
+        return false;
+    }
+
+    if (filter.operator === 'exists') {
+        const hasMatch = matches.length > 0 && matches.some((v) => v !== undefined && v !== null);
+        return filter.value === false ? !hasMatch : hasMatch;
+    }
+
+    if (matches.length === 0) {
+        return false;
+    }
+
+    return matches.some((actual) => applyOperator(filter.operator, actual, filter.value));
+}
+
+function passesFilters(event, filters) {
+    if (!filters || filters.length === 0) {
+        return true;
+    }
+    if (!Array.isArray(filters)) {
+        return false;
+    }
+    return filters.every((filter) => evaluateFilter(filter, event));
+}
+
+module.exports = {
+    passesFilters,
+    evaluateFilter,
+    EVALUATION_TIMEOUT_MS,
+};

--- a/backend/src/utils/jsonpathValidator.js
+++ b/backend/src/utils/jsonpathValidator.js
@@ -1,0 +1,127 @@
+const MAX_PATH_LENGTH = 200;
+const MAX_FILTERS_PER_TRIGGER = 20;
+
+const VALID_OPERATORS = new Set([
+    'eq',
+    'neq',
+    'gt',
+    'gte',
+    'lt',
+    'lte',
+    'contains',
+    'in',
+    'exists',
+]);
+
+const PATH_ALLOWED_CHARS = /^[A-Za-z0-9_$@.\[\]'"*\s,:?()=!<>&|+-]+$/;
+
+const FORBIDDEN_PATTERNS = [
+    { pattern: /\/[^\/]*\//, message: 'Regular expressions in JSONPath are not allowed' },
+    { pattern: /\$\.\.(\*|$|[^\w])/, message: 'Recursive wildcard ($..*) is not allowed' },
+    { pattern: /\.\.\.\.+/, message: 'Excessive recursive descent is not allowed' },
+    { pattern: /eval\s*\(/i, message: 'eval() calls are not allowed' },
+    { pattern: /Function\s*\(/, message: 'Function constructor is not allowed' },
+    { pattern: /require\s*\(/i, message: 'require() calls are not allowed' },
+    { pattern: /process\./i, message: 'Access to process is not allowed' },
+];
+
+function validatePath(rawPath) {
+    if (typeof rawPath !== 'string') {
+        return { ok: false, error: 'path must be a string' };
+    }
+
+    const path = rawPath.trim();
+
+    if (path.length === 0) {
+        return { ok: false, error: 'path cannot be empty' };
+    }
+
+    if (path.length > MAX_PATH_LENGTH) {
+        return { ok: false, error: `path exceeds max length of ${MAX_PATH_LENGTH}` };
+    }
+
+    if (!path.startsWith('$')) {
+        return { ok: false, error: 'path must start with $' };
+    }
+
+    if (!PATH_ALLOWED_CHARS.test(path)) {
+        return { ok: false, error: 'path contains disallowed characters' };
+    }
+
+    for (const { pattern, message } of FORBIDDEN_PATTERNS) {
+        if (pattern.test(path)) {
+            return { ok: false, error: message };
+        }
+    }
+
+    const openBrackets = (path.match(/\[/g) || []).length;
+    const closeBrackets = (path.match(/\]/g) || []).length;
+    if (openBrackets !== closeBrackets) {
+        return { ok: false, error: 'path has unbalanced brackets' };
+    }
+
+    const openParens = (path.match(/\(/g) || []).length;
+    const closeParens = (path.match(/\)/g) || []).length;
+    if (openParens !== closeParens) {
+        return { ok: false, error: 'path has unbalanced parentheses' };
+    }
+
+    return { ok: true };
+}
+
+function validateFilter(filter) {
+    if (!filter || typeof filter !== 'object') {
+        return { ok: false, error: 'filter must be an object' };
+    }
+
+    const pathResult = validatePath(filter.path);
+    if (!pathResult.ok) {
+        return pathResult;
+    }
+
+    if (!VALID_OPERATORS.has(filter.operator)) {
+        return { ok: false, error: `operator "${filter.operator}" is not supported` };
+    }
+
+    if (filter.operator === 'in' && !Array.isArray(filter.value)) {
+        return { ok: false, error: 'operator "in" requires an array value' };
+    }
+
+    if (filter.operator !== 'exists' && filter.operator !== 'in' && filter.value === undefined) {
+        return { ok: false, error: `operator "${filter.operator}" requires a value` };
+    }
+
+    return { ok: true };
+}
+
+function validateFilters(filters) {
+    if (filters === undefined || filters === null) {
+        return { ok: true };
+    }
+
+    if (!Array.isArray(filters)) {
+        return { ok: false, error: 'filters must be an array' };
+    }
+
+    if (filters.length > MAX_FILTERS_PER_TRIGGER) {
+        return { ok: false, error: `too many filters (max ${MAX_FILTERS_PER_TRIGGER})` };
+    }
+
+    for (let i = 0; i < filters.length; i++) {
+        const result = validateFilter(filters[i]);
+        if (!result.ok) {
+            return { ok: false, error: `filters[${i}]: ${result.error}` };
+        }
+    }
+
+    return { ok: true };
+}
+
+module.exports = {
+    validatePath,
+    validateFilter,
+    validateFilters,
+    MAX_PATH_LENGTH,
+    MAX_FILTERS_PER_TRIGGER,
+    VALID_OPERATORS,
+};

--- a/backend/src/worker/poller.js
+++ b/backend/src/worker/poller.js
@@ -1,6 +1,7 @@
 const { rpc, xdr } = require('@stellar/stellar-sdk');
 const Trigger = require('../models/trigger.model');
 const logger = require('../config/logger');
+const { passesFilters } = require('../utils/filterEvaluator');
 
 const RPC_URL = process.env.SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org';
 const server = new rpc.Server(RPC_URL, {
@@ -242,6 +243,14 @@ async function pollEvents() {
                         for (const event of response.events) {
                             // Ensure the event falls within our intended window
                             if (event.ledger <= endLedger) {
+                                if (!passesFilters(event, trigger.filters)) {
+                                    logger.debug('Event filtered out by trigger filters', {
+                                        triggerId: trigger._id,
+                                        eventId: event.id,
+                                        eventLedger: event.ledger,
+                                    });
+                                    continue;
+                                }
                                 foundEvents++;
                                 const result = await executeWithRetry(trigger, event);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "express-rate-limit": "^8.3.1",
         "ioredis": "^5.3.0",
         "joi": "^18.1.1",
+        "jsonpath-plus": "^10.4.0",
         "mongoose": "^8.0.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1"
@@ -397,6 +398,30 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "license": "MIT"
+    },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
     },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.4.6",
@@ -3327,6 +3352,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "dev": true,
@@ -3341,6 +3375,24 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",


### PR DESCRIPTION
Closes #178

## Summary
Enable users to define granular filters on event payloads using JSONPath expressions, so triggers only fire when the incoming event actually matches the desired conditions.

## Changes
- **Dependency:** add `jsonpath-plus@^10.4.0` with `preventEval: true` for safe payload queries.
- **Model:** extend `Trigger` with a `filters` subdocument array (`path`, `operator`, `value`).
- **Security validator (`utils/jsonpathValidator.js`):**
  - Max path length (200) and max filters per trigger (20).
  - Whitelist of allowed characters; rejects slashes to block regex delimiters.
  - Forbidden patterns: embedded regex, `$..*`, `eval(`, `Function(`, `require(`, `process.`.
  - Balanced-bracket / balanced-parenthesis checks.
  - Closed whitelist of operators (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `in`, `exists`).
  - Enforces `in` operator requires an array and non-`exists` operators require a value.
- **Evaluator (`utils/filterEvaluator.js`):** `passesFilters(event, filters)` applies AND semantics across filters; returns `false` on invalid input or evaluation errors (fail-closed) and enforces a per-path time budget.
- **Poller integration:** events that fail filters are skipped before action execution and do not count as executions.
- **Joi schema:** `triggerCreate` now accepts an optional `filters` array, delegating security validation to the validator module.

## Example
```json
{
  "contractId": "C...",
  "eventName": "transfer",
  "actionType": "webhook",
  "actionUrl": "https://example.com/hook",
  "filters": [
    { "path": "$.value.amount", "operator": "gt", "value": 1000 },
    { "path": "$.value.currency", "operator": "in", "value": ["USDC", "XLM"] }
  ]
}
```

## Test plan
- [x] `npm test` in `backend/` — 47/47 tests pass
- [x] Validator rejects: oversized paths, missing root `$`, slash-delimited regex, `$..*`, `eval(`, `Function(`, `require(`, `process.`, unbalanced brackets/parens, unknown operators, non-array `in` values, missing comparison values, and exceeding max filter count.
- [x] Evaluator handles: exact equality (including numeric-string coercion), inequality, numeric comparisons, `contains` on arrays/strings/objects, `in` membership, `exists` presence/absence (with optional `value: false` for negative assertion), deeply nested paths (4+ levels), array wildcards (`$.items[*].name`), filter expressions (`$.items[?(@.active==true)].name`), AND semantics across multiple filters, missing paths, malformed filters (fail-closed), and non-numeric values in numeric comparisons.
- [ ] Manual verification: create a trigger via API with filters, emit a matching and a non-matching event, confirm only matching ones fire the action.