### PR TITLE
feat(backend): add circuit breakers for outbound actions

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,3 +38,10 @@ REDIS_PASSWORD=
 
 # Worker configuration
 WORKER_CONCURRENCY=5
+
+# Circuit breaker (opossum) — protects outward action calls (webhook, Slack, Telegram, OAuth)
+CB_TIMEOUT_MS=10000
+CB_FAILURE_THRESHOLD=50
+CB_RESET_TIMEOUT_MS=30000
+CB_VOLUME_THRESHOLD=5
+CB_ROLLING_WINDOW_MS=60000

--- a/backend/__tests__/circuitBreaker.test.js
+++ b/backend/__tests__/circuitBreaker.test.js
@@ -1,0 +1,109 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// Aggressive thresholds so the breaker trips fast under test.
+process.env.CB_TIMEOUT_MS = '200';
+process.env.CB_FAILURE_THRESHOLD = '50';
+process.env.CB_RESET_TIMEOUT_MS = '300';
+process.env.CB_VOLUME_THRESHOLD = '2';
+process.env.CB_ROLLING_WINDOW_MS = '5000';
+
+// Force a fresh module instance so env vars above are picked up.
+delete require.cache[require.resolve('../src/services/circuitBreaker')];
+const breakers = require('../src/services/circuitBreaker');
+const { CircuitBreakerOpenError } = breakers;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Each test uses a unique key so breakers don't bleed state into each other.
+let keyCounter = 0;
+const nextKey = (label) => `${label}-${++keyCounter}-${Date.now()}`;
+
+test('successful call returns the action result', async () => {
+    const key = nextKey('success');
+    const result = await breakers.fire(key, async (n) => n * 2, [21]);
+    assert.equal(result, 42);
+
+    const status = breakers.getStatus()[key];
+    assert.equal(status.state, 'CLOSED');
+    assert.equal(status.stats.successes, 1);
+});
+
+test('repeated failures trip the breaker to OPEN and subsequent calls fast-fail', async () => {
+    const key = nextKey('fail');
+    const failing = async () => { throw new Error('downstream boom'); };
+
+    // Drive enough failures to exceed the 50% threshold over the volume window.
+    for (let i = 0; i < 5; i++) {
+        await assert.rejects(breakers.fire(key, failing));
+    }
+
+    const status = breakers.getStatus()[key];
+    assert.equal(status.state, 'OPEN', 'expected breaker to be OPEN after sustained failures');
+
+    // Next call should fast-fail with the typed error rather than invoking the action.
+    let invoked = false;
+    const probe = async () => { invoked = true; };
+    await assert.rejects(
+        breakers.fire(key, probe),
+        (err) => err instanceof CircuitBreakerOpenError && err.code === 'CIRCUIT_OPEN'
+    );
+    assert.equal(invoked, false, 'action must not run while breaker is OPEN');
+});
+
+test('breaker transitions through HALF_OPEN and recloses on a successful probe', async () => {
+    const key = nextKey('recover');
+    const failing = async () => { throw new Error('boom'); };
+
+    for (let i = 0; i < 5; i++) {
+        await assert.rejects(breakers.fire(key, failing));
+    }
+    assert.equal(breakers.getStatus()[key].state, 'OPEN');
+
+    // Wait for resetTimeout so the breaker enters HALF_OPEN on the next call.
+    await sleep(400);
+
+    // A successful probe call should close the breaker.
+    const result = await breakers.fire(key, async () => 'recovered');
+    assert.equal(result, 'recovered');
+    assert.equal(breakers.getStatus()[key].state, 'CLOSED');
+});
+
+test('timeouts count as failures', async () => {
+    const key = nextKey('timeout');
+    const slow = () => new Promise((resolve) => setTimeout(() => resolve('late'), 1000));
+
+    // CB_TIMEOUT_MS is 200, so this should reject with a Timed out error.
+    await assert.rejects(breakers.fire(key, slow));
+
+    const status = breakers.getStatus()[key];
+    assert.equal(status.stats.timeouts >= 1, true, 'expected at least one timeout');
+});
+
+test('getStatus exposes per-breaker state, stats, and config', async () => {
+    const key = nextKey('status');
+    await breakers.fire(key, async () => 'ok');
+
+    const all = breakers.getStatus();
+    assert.ok(all[key], 'breaker should appear in status snapshot');
+    assert.ok(['CLOSED', 'OPEN', 'HALF_OPEN'].includes(all[key].state));
+    assert.equal(typeof all[key].stats.successes, 'number');
+    assert.equal(typeof all[key].config.timeout, 'number');
+    assert.equal(typeof all[key].config.errorThresholdPercentage, 'number');
+});
+
+test('isolated keys do not affect each other', async () => {
+    const failingKey = nextKey('isolation-fail');
+    const healthyKey = nextKey('isolation-ok');
+    const failing = async () => { throw new Error('boom'); };
+
+    for (let i = 0; i < 5; i++) {
+        await assert.rejects(breakers.fire(failingKey, failing));
+    }
+    assert.equal(breakers.getStatus()[failingKey].state, 'OPEN');
+
+    // Healthy key must still allow calls through.
+    const result = await breakers.fire(healthyKey, async () => 'fine');
+    assert.equal(result, 'fine');
+    assert.equal(breakers.getStatus()[healthyKey].state, 'CLOSED');
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,6 +2,9 @@
   "name": "backend",
   "version": "1.0.0",
   "main": "src/server.js",
+  "engines": {
+    "node": "^20 || ^22 || ^24"
+  },
   "scripts": {
     "start": "node src/server.js",
     "dev": "nodemon src/server.js",
@@ -23,6 +26,7 @@
     "jsonwebtoken": "^9.0.3",
     "mongoose": "^8.0.0",
     "node-vault": "^0.10.2",
+    "opossum": "^9.0.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"
   },

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -48,6 +48,7 @@ app.use('/api/discovery', require('./routes/discovery.routes'));
  *                   example: ok
  */
 app.get('/api/health', (_req, res) => res.json({ status: 'ok' }));
+app.use('/api/health', require('./routes/health.routes'));
 
 app.use(errorLogger);
 app.use(notFoundHandler);

--- a/backend/src/controllers/oauth.controller.js
+++ b/backend/src/controllers/oauth.controller.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const Credential = require('../models/credential.model');
 const { encrypt } = require('../utils/encryption');
 const { PROVIDERS } = require('../services/oauth.service');
+const breakers = require('../services/circuitBreaker');
 const logger = require('../config/logger');
 
 /**
@@ -41,15 +42,21 @@ exports.callback = async (req, res) => {
     const userId = state; // We passed userId as 'state' in authorize
 
     try {
-        const response = await axios.post(config.tokenUrl, new URLSearchParams({
-            client_id: config.clientId,
-            client_secret: config.clientSecret,
-            code,
-            redirect_uri: `${process.env.APP_URL}/api/auth/${provider}/callback`,
-            grant_type: 'authorization_code'
-        }).toString(), {
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
-        });
+        const response = await breakers.fire(
+            `oauth:${provider}`,
+            (tokenUrl, body, cfg) => axios.post(tokenUrl, body, cfg),
+            [
+                config.tokenUrl,
+                new URLSearchParams({
+                    client_id: config.clientId,
+                    client_secret: config.clientSecret,
+                    code,
+                    redirect_uri: `${process.env.APP_URL}/api/auth/${provider}/callback`,
+                    grant_type: 'authorization_code'
+                }).toString(),
+                { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+            ]
+        );
 
         const { access_token, refresh_token, expires_in, scope } = response.data;
 

--- a/backend/src/routes/health.routes.js
+++ b/backend/src/routes/health.routes.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const router = express.Router();
+const breakers = require('../services/circuitBreaker');
+
+/**
+ * @openapi
+ * /api/health/circuit-breakers:
+ *   get:
+ *     summary: Circuit breaker status
+ *     description: |
+ *       Returns the current state (CLOSED, OPEN, HALF_OPEN) and rolling
+ *       statistics for every outward-call circuit breaker registered in the
+ *       process. Used by operators to detect 'poison pill' downstream
+ *       endpoints that have tripped their breaker.
+ *     tags:
+ *       - Health
+ *     responses:
+ *       200:
+ *         description: Map of breaker key to state and statistics.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 circuitBreakers:
+ *                   type: object
+ *                   additionalProperties:
+ *                     type: object
+ *                     properties:
+ *                       state:
+ *                         type: string
+ *                         enum: [CLOSED, OPEN, HALF_OPEN]
+ *                       stats:
+ *                         type: object
+ *                       config:
+ *                         type: object
+ */
+router.get('/circuit-breakers', (_req, res) => {
+    res.json({ circuitBreakers: breakers.getStatus() });
+});
+
+module.exports = router;

--- a/backend/src/services/circuitBreaker.js
+++ b/backend/src/services/circuitBreaker.js
@@ -1,0 +1,131 @@
+const CircuitBreaker = require('opossum');
+const logger = require('../config/logger');
+
+const DEFAULTS = {
+    timeout: parseInt(process.env.CB_TIMEOUT_MS, 10) || 10000,
+    errorThresholdPercentage: parseInt(process.env.CB_FAILURE_THRESHOLD, 10) || 50,
+    resetTimeout: parseInt(process.env.CB_RESET_TIMEOUT_MS, 10) || 30000,
+    volumeThreshold: parseInt(process.env.CB_VOLUME_THRESHOLD, 10) || 5,
+    rollingCountTimeout: parseInt(process.env.CB_ROLLING_WINDOW_MS, 10) || 60000,
+    rollingCountBuckets: 10,
+};
+
+class CircuitBreakerOpenError extends Error {
+    constructor(key) {
+        super(`Circuit breaker is OPEN for "${key}" — fast-failing request.`);
+        this.name = 'CircuitBreakerOpenError';
+        this.code = 'CIRCUIT_OPEN';
+        this.breakerKey = key;
+    }
+}
+
+class CircuitBreakerRegistry {
+    constructor() {
+        this.breakers = new Map();
+    }
+
+    /**
+     * Get or create a circuit breaker for a given key.
+     *
+     * Internally we bind opossum to a generic dispatcher `(fn, args) => fn(...args)`
+     * so each fire() call can supply its own action — opossum normally binds a
+     * single action at construction. This lets us re-use one breaker per logical
+     * downstream (e.g. one per webhook URL) regardless of which call site invokes it.
+     *
+     * @param {string} key - Unique identifier for this breaker (e.g. "slack", "webhook:<url>")
+     * @param {object} options - Override defaults for this breaker
+     * @returns {CircuitBreaker}
+     */
+    getBreaker(key, options = {}) {
+        if (this.breakers.has(key)) {
+            return this.breakers.get(key);
+        }
+
+        const dispatcher = (fn, args) => fn(...args);
+        const breaker = new CircuitBreaker(dispatcher, {
+            ...DEFAULTS,
+            ...options,
+            name: key,
+        });
+
+        breaker.on('open', () => {
+            logger.warn('Circuit breaker OPENED', { key, stats: breaker.stats });
+        });
+        breaker.on('halfOpen', () => {
+            logger.info('Circuit breaker HALF-OPEN — probing recovery', { key });
+        });
+        breaker.on('close', () => {
+            logger.info('Circuit breaker CLOSED — recovered', { key });
+        });
+        breaker.on('reject', () => {
+            logger.debug('Circuit breaker rejected call (still OPEN)', { key });
+        });
+        breaker.on('timeout', () => {
+            logger.warn('Circuit breaker call timed out', { key });
+        });
+
+        this.breakers.set(key, breaker);
+        return breaker;
+    }
+
+    /**
+     * Execute an action via its circuit breaker. Translates opossum's generic
+     * "Breaker is open" rejection into a typed CircuitBreakerOpenError so
+     * callers can distinguish fast-fail from genuine downstream failures.
+     */
+    async fire(key, action, args = [], options = {}) {
+        const breaker = this.getBreaker(key, options);
+        try {
+            return await breaker.fire(action, args);
+        } catch (err) {
+            if (breaker.opened && err && /Breaker is open/i.test(err.message || '')) {
+                throw new CircuitBreakerOpenError(key);
+            }
+            throw err;
+        }
+    }
+
+    /**
+     * Snapshot of all breakers for monitoring endpoints.
+     */
+    getStatus() {
+        const status = {};
+        for (const [key, breaker] of this.breakers.entries()) {
+            let state = 'CLOSED';
+            if (breaker.opened) state = 'OPEN';
+            else if (breaker.halfOpen) state = 'HALF_OPEN';
+
+            const s = breaker.stats;
+            status[key] = {
+                state,
+                stats: {
+                    successes: s.successes,
+                    failures: s.failures,
+                    rejects: s.rejects,
+                    timeouts: s.timeouts,
+                    fires: s.fires,
+                    fallbacks: s.fallbacks,
+                    latencyMean: s.latencyMean,
+                    percentiles: s.percentiles,
+                },
+                config: {
+                    timeout: breaker.options.timeout,
+                    errorThresholdPercentage: breaker.options.errorThresholdPercentage,
+                    resetTimeout: breaker.options.resetTimeout,
+                    volumeThreshold: breaker.options.volumeThreshold,
+                },
+            };
+        }
+        return status;
+    }
+
+    reset(key) {
+        const breaker = this.breakers.get(key);
+        if (breaker) breaker.close();
+    }
+}
+
+const registry = new CircuitBreakerRegistry();
+
+module.exports = registry;
+module.exports.CircuitBreakerOpenError = CircuitBreakerOpenError;

--- a/backend/src/services/oauth.service.js
+++ b/backend/src/services/oauth.service.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const Credential = require('../models/credential.model');
 const { encrypt, decrypt } = require('../utils/encryption');
 const logger = require('../config/logger');
+const breakers = require('./circuitBreaker');
 
 // Configuration for supported providers
 const PROVIDERS = {
@@ -31,14 +32,20 @@ async function refreshAccessToken(credential) {
     try {
         const plainRefreshToken = decrypt(credential.refreshToken);
         
-        const response = await axios.post(config.tokenUrl, new URLSearchParams({
-            client_id: config.clientId,
-            client_secret: config.clientSecret,
-            grant_type: 'refresh_token',
-            refresh_token: plainRefreshToken
-        }).toString(), {
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
-        });
+        const response = await breakers.fire(
+            `oauth:${credential.provider}`,
+            (tokenUrl, body, cfg) => axios.post(tokenUrl, body, cfg),
+            [
+                config.tokenUrl,
+                new URLSearchParams({
+                    client_id: config.clientId,
+                    client_secret: config.clientSecret,
+                    grant_type: 'refresh_token',
+                    refresh_token: plainRefreshToken
+                }).toString(),
+                { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+            ]
+        );
 
         const { access_token, refresh_token, expires_in } = response.data;
         

--- a/backend/src/services/slack.service.js
+++ b/backend/src/services/slack.service.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const breakers = require('./circuitBreaker');
 
 /**
  * Service to handle Slack Webhook notifications
@@ -102,9 +103,17 @@ class SlackService {
 
         try {
             // Slack webhook payload size limit is generally 100KB
-            const response = await axios.post(webhookUrl, message);
+            const response = await breakers.fire(
+                'slack',
+                (url, msg) => axios.post(url, msg),
+                [webhookUrl, message]
+            );
             return { success: true, data: response.data };
         } catch (error) {
+            if (error.code === 'CIRCUIT_OPEN') {
+                console.error('Slack circuit breaker OPEN — fast-failing.');
+                return { success: false, status: 503, message: 'circuit_open' };
+            }
             if (error.response) {
                 const { status, data, headers } = error.response;
 

--- a/backend/src/services/telegram.service.js
+++ b/backend/src/services/telegram.service.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const breakers = require('./circuitBreaker');
 
 /**
  * Service to handle Telegram Bot notifications
@@ -20,14 +21,22 @@ class TelegramService {
         const url = `https://api.telegram.org/bot${botToken}/sendMessage`;
 
         try {
-            const response = await axios.post(url, {
-                chat_id: chatId,
-                text: text,
-                parse_mode: 'MarkdownV2'
-            });
+            const response = await breakers.fire(
+                'telegram',
+                (postUrl, body) => axios.post(postUrl, body),
+                [url, {
+                    chat_id: chatId,
+                    text: text,
+                    parse_mode: 'MarkdownV2'
+                }]
+            );
 
             return response.data;
         } catch (error) {
+            if (error.code === 'CIRCUIT_OPEN') {
+                console.error('Telegram circuit breaker OPEN — fast-failing.');
+                return { success: false, status: 503, message: 'circuit_open' };
+            }
             // Graceful error handling for common Telegram API issues
             if (error.response) {
                 const { status, data } = error.response;

--- a/backend/src/services/webhook.service.js
+++ b/backend/src/services/webhook.service.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const crypto = require('crypto');
 const logger = require('../config/logger');
+const breakers = require('./circuitBreaker');
 
 /**
  * Webhook service for secure outbound webhook delivery with HMAC signing
@@ -49,11 +50,17 @@ class WebhookService {
         });
 
         try {
-            const response = await axios.post(url, payload, {
-                headers,
-                timeout: options.timeout || 30000, // 30 second timeout
-                ...options
-            });
+            const breakerKey = `webhook:${url}`;
+            const response = await breakers.fire(
+                breakerKey,
+                (postUrl, postPayload, postConfig) => axios.post(postUrl, postPayload, postConfig),
+                [url, payload, {
+                    headers,
+                    timeout: options.timeout || 30000, // 30 second timeout
+                    ...options
+                }],
+                { timeout: options.timeout || 30000 }
+            );
 
             logger.info('Webhook sent successfully', {
                 url,

--- a/backend/src/worker/poller.js
+++ b/backend/src/worker/poller.js
@@ -72,6 +72,7 @@ try {
 
     // Fallback: direct execution with full action routing
     const axios = require('axios');
+    const breakers = require('../services/circuitBreaker');
     const { sendEventNotification } = require('../services/email.service');
     const { sendDiscordNotification } = require('../services/discord.service');
     const slackService = require('../services/slack.service');
@@ -137,11 +138,15 @@ try {
                 if (!actionUrl) {
                     throw new Error('Missing actionUrl for webhook trigger');
                 }
-                return await axios.post(actionUrl, {
-                    contractId,
-                    eventName,
-                    payload: eventPayload,
-                });
+                return await breakers.fire(
+                    `webhook:${actionUrl}`,
+                    (url, body) => axios.post(url, body),
+                    [actionUrl, {
+                        contractId,
+                        eventName,
+                        payload: eventPayload,
+                    }]
+                );
 
             default:
                 throw new Error(`Unsupported action type: ${actionType}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "jsonpath-plus": "^10.4.0",
         "jsonwebtoken": "^9.0.3",
         "mongoose": "^8.0.0",
-        "redlock": "^5.0.0-beta.2",
+        "node-vault": "^0.10.2",
+        "opossum": "^9.0.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1"
       },
@@ -675,6 +676,7 @@
       "version": "18.3.28",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -735,6 +737,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1206,6 +1209,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1951,6 +1955,7 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2248,6 +2253,7 @@
     "node_modules/express": {
       "version": "4.22.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3319,6 +3325,7 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3360,6 +3367,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -3943,6 +3951,15 @@
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
       }
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "dev": true,
@@ -4051,6 +4068,44 @@
     "node_modules/node-releases": {
       "version": "2.0.36",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-vault": {
+      "version": "0.10.10",
+      "resolved": "https://registry.npmjs.org/node-vault/-/node-vault-0.10.10.tgz",
+      "integrity": "sha512-gag25B9pi4RpPHvadnoySfh80BkFzYo1zHFVv+wrahnLvmrnIUUevM0A+pVcAgCheJr/H1RSrxrBIwPfG3nImQ==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.13.6",
+        "debug": "^4.3.4",
+        "mustache": "^4.2.0",
+        "tv4": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/node-vault/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-vault/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/nodemon": {
@@ -4233,6 +4288,15 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/opossum": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-9.0.0.tgz",
+      "integrity": "sha512-K76U0QkxOfUZamneQuzz+AP0fyfTJcCplZ2oZL93nxeupuJbN4s6uFNbmVCt4eWqqGqRnnowdFuBicJ1fLMVxw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^24 || ^22 || ^20"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "dev": true,
@@ -4400,6 +4464,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4657,6 +4722,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4718,18 +4784,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/redlock": {
-      "version": "5.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/redlock/-/redlock-5.0.0-beta.2.tgz",
-      "integrity": "sha512-2RDWXg5jgRptDrB1w9O/JgSZC0j7y4SlaXnor93H/UJm/QyDiFgBKNtrh0TI6oCXqYSaSoXxFh6Sd3VtYfhRXw==",
-      "license": "MIT",
-      "dependencies": {
-        "node-abort-controller": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5611,6 +5665,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5682,6 +5737,24 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tv4": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+      "integrity": "sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==",
+      "license": [
+        {
+          "type": "Public Domain",
+          "url": "http://geraintluff.github.io/tv4/LICENSE.txt"
+        },
+        {
+          "type": "MIT",
+          "url": "http://jsonary.com/LICENSE.txt"
+        }
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
@@ -5904,6 +5977,7 @@
       "version": "4.5.14",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",


### PR DESCRIPTION
   Closes #179. 

## Summary

  Implements a centralized circuit breaker layer for EventHorizon's implemented outward calls:
  webhook, Slack, Telegram, and OAuth. This protects the backend from slow or failing downstream
  endpoints and prevents repeated calls to "poison pill" destinations.



  ## What Changed

  ### Added

  - `backend/src/services/circuitBreaker.js`
    - Singleton circuit breaker registry built on `opossum`
    - Exposes `fire()`, `getStatus()`, and `CircuitBreakerOpenError`
    - Tracks breaker state per destination key

  - `backend/src/routes/health.routes.js`
    - Adds `GET /api/health/circuit-breakers`
    - Returns breaker state, rolling stats, and effective config
    - Read-only endpoint; no reset/mutation route exposed

  - `backend/__tests__/circuitBreaker.test.js`
    - Covers success path
    - OPEN trip and fast-fail behavior
    - HALF_OPEN to CLOSED recovery
    - Timeouts as failures
    - Status snapshot shape
    - Key isolation

  ### Wrapped Outward Calls

  - Webhooks: `webhook:<url>`
  - Slack: `slack`
  - Telegram: `telegram`
  - OAuth refresh: `oauth:<provider>`
  - OAuth initial token exchange: `oauth:<provider>`
  - No-queue fallback webhook path: `webhook:<url>`

  ## Configuration

  Added circuit breaker settings to `backend/.env.example`:

  - `CB_TIMEOUT_MS=10000`
  - `CB_FAILURE_THRESHOLD=50`
  - `CB_RESET_TIMEOUT_MS=30000`
  - `CB_VOLUME_THRESHOLD=5`
  - `CB_ROLLING_WINDOW_MS=60000`

  ## Monitoring

  `GET /api/health/circuit-breakers` returns each registered breaker with:

  - State: `CLOSED`, `OPEN`, or `HALF_OPEN`
  - Rolling stats: successes, failures, rejects, timeouts, fires, latency
  - Effective config: timeout, failure threshold, reset timeout, volume threshold

  ## Test Plan

  - [x] `node --test backend/__tests__/circuitBreaker.test.js` passes 6/6
  - [x] Full backend suite run: 57 passing, 4 pre-existing unrelated failures
 

  ## Notes

  `email.service.js` and `discord.service.js` are referenced by existing worker code but do not
  exist in the repo. Those broken imports are pre-existing and are out of scope for this PR.

  No manual reset endpoint is exposed because the issue only requires status visibility, and
  unauthenticated breaker mutation would weaken the protection.
