### PR TITLE
   feat(backend): contract list refresh job for new LiquifactEscrow wasm deployment (#134)

### DIFF
--- a/backend/__tests__/escrowVersions.test.js
+++ b/backend/__tests__/escrowVersions.test.js
@@ -1,0 +1,262 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  VERSION_REGISTRY,
+  semverForSchemaVersion,
+  latestKnownSchemaVersion,
+  checkOnChainVersion,
+} = require('../src/config/escrowVersions');
+
+// ── VERSION_REGISTRY ──────────────────────────────────────────────────────────
+
+test('VERSION_REGISTRY is frozen and non-empty', () => {
+  assert.ok(Object.isFrozen(VERSION_REGISTRY));
+  assert.ok(Object.keys(VERSION_REGISTRY).length > 0);
+});
+
+test('VERSION_REGISTRY values are positive integers', () => {
+  for (const v of Object.values(VERSION_REGISTRY)) {
+    assert.ok(Number.isInteger(v) && v > 0, `Expected positive integer, got ${v}`);
+  }
+});
+
+// ── semverForSchemaVersion ────────────────────────────────────────────────────
+
+test('semverForSchemaVersion returns correct semver for known version', () => {
+  // Every registry entry should round-trip.
+  for (const [semver, sv] of Object.entries(VERSION_REGISTRY)) {
+    assert.equal(semverForSchemaVersion(sv), semver);
+  }
+});
+
+test('semverForSchemaVersion returns null for unknown version', () => {
+  assert.equal(semverForSchemaVersion(9999), null);
+  assert.equal(semverForSchemaVersion(0), null);
+});
+
+// ── latestKnownSchemaVersion ──────────────────────────────────────────────────
+
+test('latestKnownSchemaVersion returns the maximum registry value', () => {
+  const expected = Math.max(...Object.values(VERSION_REGISTRY));
+  assert.equal(latestKnownSchemaVersion(), expected);
+});
+
+// ── checkOnChainVersion ───────────────────────────────────────────────────────
+
+test('checkOnChainVersion throws when LIQUIFACT_ESCROW_CONTRACT_ID is unset', async () => {
+  const saved = process.env.LIQUIFACT_ESCROW_CONTRACT_ID;
+  delete process.env.LIQUIFACT_ESCROW_CONTRACT_ID;
+
+  await assert.rejects(
+    () => checkOnChainVersion(),
+    /LIQUIFACT_ESCROW_CONTRACT_ID is not set/
+  );
+
+  if (saved !== undefined) process.env.LIQUIFACT_ESCROW_CONTRACT_ID = saved;
+});
+
+test('checkOnChainVersion returns correct shape for a known version', async () => {
+  process.env.LIQUIFACT_ESCROW_CONTRACT_ID = 'CTEST000';
+
+  const latestSv = latestKnownSchemaVersion();
+  const result = await checkOnChainVersion({
+    fetchSchemaVersion: async () => latestSv,
+  });
+
+  assert.equal(result.onChainVersion, latestSv);
+  assert.equal(typeof result.semver, 'string');
+  assert.equal(result.isLatest, true);
+  assert.equal(result.latestKnown, latestSv);
+
+  delete process.env.LIQUIFACT_ESCROW_CONTRACT_ID;
+});
+
+test('checkOnChainVersion isLatest=false when on-chain version is older', async () => {
+  process.env.LIQUIFACT_ESCROW_CONTRACT_ID = 'CTEST001';
+
+  const result = await checkOnChainVersion({
+    fetchSchemaVersion: async () => 1,
+  });
+
+  assert.equal(result.onChainVersion, 1);
+  assert.equal(result.isLatest, false);
+
+  delete process.env.LIQUIFACT_ESCROW_CONTRACT_ID;
+});
+
+test('checkOnChainVersion semver is null for unregistered on-chain version', async () => {
+  process.env.LIQUIFACT_ESCROW_CONTRACT_ID = 'CTEST002';
+
+  const result = await checkOnChainVersion({
+    fetchSchemaVersion: async () => 9999,
+  });
+
+  assert.equal(result.semver, null);
+  assert.equal(result.isLatest, true); // 9999 >= latestKnown
+
+  delete process.env.LIQUIFACT_ESCROW_CONTRACT_ID;
+});
+
+test('checkOnChainVersion propagates errors from fetchSchemaVersion', async () => {
+  process.env.LIQUIFACT_ESCROW_CONTRACT_ID = 'CTEST003';
+
+  await assert.rejects(
+    () =>
+      checkOnChainVersion({
+        fetchSchemaVersion: async () => {
+          throw new Error('RPC timeout');
+        },
+      }),
+    /RPC timeout/
+  );
+
+  delete process.env.LIQUIFACT_ESCROW_CONTRACT_ID;
+});
+
+// ── /api/escrow/refresh route ─────────────────────────────────────────────────
+
+// Minimal Express-like request/response helpers for unit-testing the route
+// handler without starting a real HTTP server.
+
+function makeReq(overrides = {}) {
+  return {
+    headers: {},
+    ...overrides,
+  };
+}
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    _body: null,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    json(body) {
+      this._body = body;
+      return this;
+    },
+  };
+  return res;
+}
+
+// Load the router and extract the POST /refresh handler directly.
+const escrowRouter = require('../src/routes/escrow.routes');
+
+// Walk the router's stack to find the POST /refresh layer.
+function findHandler(router, method, path) {
+  for (const layer of router.stack) {
+    if (
+      layer.route &&
+      layer.route.path === path &&
+      layer.route.methods[method]
+    ) {
+      return layer.route.stack.map((l) => l.handle);
+    }
+  }
+  return null;
+}
+
+const refreshHandlers = findHandler(escrowRouter, 'post', '/refresh');
+assert.ok(refreshHandlers, 'POST /refresh route must exist');
+
+const [adminAuthFn, refreshFn] = refreshHandlers;
+
+test('POST /refresh returns 401 when X-Admin-Token header is missing', () => {
+  process.env.ADMIN_ACCESS_TOKEN = 'secret';
+  const req = makeReq({ headers: {} });
+  const res = makeRes();
+  let nextCalled = false;
+
+  adminAuthFn(req, res, () => { nextCalled = true; });
+
+  assert.equal(res._status, 401);
+  assert.equal(res._body.success, false);
+  assert.ok(!nextCalled);
+
+  delete process.env.ADMIN_ACCESS_TOKEN;
+});
+
+test('POST /refresh returns 403 when X-Admin-Token is wrong', () => {
+  process.env.ADMIN_ACCESS_TOKEN = 'correct-secret';
+  const req = makeReq({ headers: { 'x-admin-token': 'wrong' } });
+  const res = makeRes();
+  let nextCalled = false;
+
+  adminAuthFn(req, res, () => { nextCalled = true; });
+
+  assert.equal(res._status, 403);
+  assert.equal(res._body.success, false);
+  assert.ok(!nextCalled);
+
+  delete process.env.ADMIN_ACCESS_TOKEN;
+});
+
+test('POST /refresh returns 503 when ADMIN_ACCESS_TOKEN is not configured', () => {
+  delete process.env.ADMIN_ACCESS_TOKEN;
+  const req = makeReq({ headers: { 'x-admin-token': 'anything' } });
+  const res = makeRes();
+
+  adminAuthFn(req, res, () => {});
+
+  assert.equal(res._status, 503);
+  assert.equal(res._body.success, false);
+});
+
+test('POST /refresh passes auth and returns version data when token is correct', async () => {
+  process.env.ADMIN_ACCESS_TOKEN = 'secret';
+  process.env.LIQUIFACT_ESCROW_CONTRACT_ID = 'CTEST_ROUTE';
+
+  const req = makeReq({ headers: { 'x-admin-token': 'secret' } });
+  const res = makeRes();
+
+  // Patch via the same require path the route uses so we hit the same cache entry.
+  const escrowVersions = require('../src/config/escrowVersions');
+  const original = escrowVersions.checkOnChainVersion;
+  const latestSv = latestKnownSchemaVersion();
+  escrowVersions.checkOnChainVersion = async () => ({
+    onChainVersion: latestSv,
+    semver: '2.0.0',
+    isLatest: true,
+    latestKnown: latestSv,
+  });
+
+  await refreshFn(req, res, () => {});
+
+  assert.equal(res._status, 200);
+  assert.equal(res._body.success, true);
+  assert.equal(typeof res._body.data.onChainVersion, 'number');
+  assert.equal(typeof res._body.data.refreshTriggered, 'boolean');
+
+  escrowVersions.checkOnChainVersion = original;
+  delete process.env.ADMIN_ACCESS_TOKEN;
+  delete process.env.LIQUIFACT_ESCROW_CONTRACT_ID;
+});
+
+test('POST /refresh returns 500 when version check throws', async () => {
+  process.env.ADMIN_ACCESS_TOKEN = 'secret';
+  process.env.LIQUIFACT_ESCROW_CONTRACT_ID = 'CTEST_ERR';
+
+  const req = makeReq({ headers: { 'x-admin-token': 'secret' } });
+  const res = makeRes();
+
+  const escrowVersions = require('../src/config/escrowVersions');
+  const original = escrowVersions.checkOnChainVersion;
+  escrowVersions.checkOnChainVersion = async () => {
+    throw new Error('chain unreachable');
+  };
+
+  await refreshFn(req, res, () => {});
+
+  assert.equal(res._status, 500);
+  assert.equal(res._body.success, false);
+  assert.match(res._body.error, /chain unreachable/);
+
+  escrowVersions.checkOnChainVersion = original;
+  delete process.env.ADMIN_ACCESS_TOKEN;
+  delete process.env.LIQUIFACT_ESCROW_CONTRACT_ID;
+});

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -27,6 +27,7 @@ app.use('/api/invitations', require('./routes/invitation.routes'));
 // app.use('/api/team', require('./routes/team.routes'));
 app.use('/api/queue', require('./routes/queue.routes'));
 app.use('/api/discovery', require('./routes/discovery.routes'));
+app.use('/api/escrow', require('./routes/escrow.routes'));
 /**
  * @openapi
  * /api/health:

--- a/backend/src/config/escrowVersions.js
+++ b/backend/src/config/escrowVersions.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const logger = require('./logger');
+
+/**
+ * Registry mapping semver -> on-chain SCHEMA_VERSION integer for known
+ * LiquifactEscrow wasm deployments.
+ *
+ * Add a new entry here whenever a new wasm is deployed to production.
+ * Keys are semver strings; values are the u32 SCHEMA_VERSION stored in
+ * the contract's persistent storage.
+ */
+const VERSION_REGISTRY = Object.freeze({
+  '1.0.0': 1,
+  '1.1.0': 2,
+  '2.0.0': 3,
+});
+
+/**
+ * Returns the semver string for a given on-chain SCHEMA_VERSION, or null
+ * if the version is not in the registry.
+ *
+ * @param {number} schemaVersion
+ * @returns {string|null}
+ */
+function semverForSchemaVersion(schemaVersion) {
+  for (const [semver, sv] of Object.entries(VERSION_REGISTRY)) {
+    if (sv === schemaVersion) return semver;
+  }
+  return null;
+}
+
+/**
+ * Returns the latest known SCHEMA_VERSION in the registry.
+ *
+ * @returns {number}
+ */
+function latestKnownSchemaVersion() {
+  return Math.max(...Object.values(VERSION_REGISTRY));
+}
+
+/**
+ * Fetches the current SCHEMA_VERSION from the on-chain LiquifactEscrow
+ * contract and compares it against the registry.
+ *
+ * Requires:
+ *   LIQUIFACT_ESCROW_CONTRACT_ID  – Soroban contract address
+ *   SOROBAN_RPC_URL               – RPC endpoint (falls back to testnet)
+ *   NETWORK_PASSPHRASE            – Stellar network passphrase
+ *
+ * @param {{ fetchSchemaVersion?: Function }} [deps] - injectable for testing
+ * @returns {Promise<{
+ *   onChainVersion: number,
+ *   semver: string|null,
+ *   isLatest: boolean,
+ *   latestKnown: number
+ * }>}
+ */
+async function checkOnChainVersion(deps = {}) {
+  const contractId = process.env.LIQUIFACT_ESCROW_CONTRACT_ID;
+  if (!contractId) {
+    throw new Error('LIQUIFACT_ESCROW_CONTRACT_ID is not set');
+  }
+
+  const rpcUrl =
+    process.env.SOROBAN_RPC_URL ||
+    'https://soroban-testnet.stellar.org';
+
+  const fetchFn = deps.fetchSchemaVersion || _fetchSchemaVersionFromChain;
+
+  const onChainVersion = await fetchFn(contractId, rpcUrl);
+  const semver = semverForSchemaVersion(onChainVersion);
+  const latestKnown = latestKnownSchemaVersion();
+
+  logger.info('LiquifactEscrow version check', {
+    contractId,
+    onChainVersion,
+    semver,
+    latestKnown,
+    isLatest: onChainVersion >= latestKnown,
+  });
+
+  return {
+    onChainVersion,
+    semver,
+    isLatest: onChainVersion >= latestKnown,
+    latestKnown,
+  };
+}
+
+/**
+ * Reads SCHEMA_VERSION from the contract's persistent storage via
+ * simulateTransaction (read-only, no fee required).
+ *
+ * @param {string} contractId
+ * @param {string} rpcUrl
+ * @returns {Promise<number>}
+ */
+async function _fetchSchemaVersionFromChain(contractId, rpcUrl) {
+  // Lazy-require to keep startup fast and allow mocking in tests.
+  const { SorobanRpc, Contract, xdr, nativeToScVal } =
+    require('@stellar/stellar-sdk');
+
+  const server = new SorobanRpc.Server(rpcUrl, { allowHttp: true });
+  const contract = new Contract(contractId);
+
+  // Call the view function `schema_version()` which returns a u32.
+  const tx = contract.call('schema_version');
+
+  const result = await server.simulateTransaction(tx);
+
+  if (SorobanRpc.Api.isSimulationError(result)) {
+    throw new Error(
+      `Contract simulation failed: ${result.error}`
+    );
+  }
+
+  const returnVal = result.result?.retval;
+  if (!returnVal) {
+    throw new Error('Contract returned no value for schema_version()');
+  }
+
+  // retval is an xdr.ScVal; extract the u32 integer.
+  const scVal = xdr.ScVal.fromXDR(returnVal.toXDR());
+  return scVal.u32();
+}
+
+module.exports = {
+  VERSION_REGISTRY,
+  semverForSchemaVersion,
+  latestKnownSchemaVersion,
+  checkOnChainVersion,
+};

--- a/backend/src/routes/escrow.routes.js
+++ b/backend/src/routes/escrow.routes.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const escrowVersions = require('../config/escrowVersions');
+const logger = require('../config/logger');
+
+/**
+ * Admin token middleware – mirrors the pattern used by audit.routes.js.
+ * Reads ADMIN_ACCESS_TOKEN from the environment; rejects with 401 if
+ * the header is absent and 403 if it does not match.
+ */
+function adminAuth(req, res, next) {
+  const token = process.env.ADMIN_ACCESS_TOKEN;
+  if (!token) {
+    return res.status(503).json({
+      success: false,
+      error: 'Admin access is not configured on this server.',
+    });
+  }
+
+  const provided = req.headers['x-admin-token'];
+  if (!provided) {
+    return res.status(401).json({ success: false, error: 'Missing X-Admin-Token header.' });
+  }
+  if (provided !== token) {
+    return res.status(403).json({ success: false, error: 'Invalid admin token.' });
+  }
+
+  next();
+}
+
+/**
+ * @openapi
+ * /api/escrow/refresh:
+ *   post:
+ *     summary: Trigger a contract list refresh
+ *     description: >
+ *       Admin-only. Reads the current on-chain SCHEMA_VERSION of the
+ *       LiquifactEscrow contract, compares it against the local version
+ *       registry, and returns whether a refresh is needed.
+ *       Requires the X-Admin-Token header.
+ *     tags: [Admin, Escrow]
+ *     security:
+ *       - adminAuth: []
+ *     responses:
+ *       200:
+ *         description: Version check completed.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     onChainVersion:
+ *                       type: integer
+ *                     semver:
+ *                       type: string
+ *                       nullable: true
+ *                     isLatest:
+ *                       type: boolean
+ *                     latestKnown:
+ *                       type: integer
+ *                     refreshTriggered:
+ *                       type: boolean
+ *       401:
+ *         description: Missing admin token.
+ *       403:
+ *         description: Invalid admin token.
+ *       500:
+ *         description: Version check failed.
+ *       503:
+ *         description: Admin access not configured.
+ */
+router.post('/refresh', adminAuth, async (req, res) => {
+  try {
+    const result = await escrowVersions.checkOnChainVersion();
+    const refreshTriggered = !result.isLatest;
+
+    if (refreshTriggered) {
+      logger.info('LiquifactEscrow contract list refresh triggered', result);
+      // Extension point: emit an event, enqueue a job, etc.
+    }
+
+    return res.json({
+      success: true,
+      data: { ...result, refreshTriggered },
+    });
+  } catch (err) {
+    logger.error('Escrow version check failed', { error: err.message });
+    return res.status(500).json({
+      success: false,
+      error: err.message,
+    });
+  }
+});
+
+module.exports = router;

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "emitter_registry",
     "flash_loan",
     "royalty_registry",
+    "session_auth",
 ]
 
 [profile.release]

--- a/contracts/session_auth/Cargo.toml
+++ b/contracts/session_auth/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "session-auth"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "23.4.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "23.4.0", features = ["testutils"] }

--- a/contracts/session_auth/src/lib.rs
+++ b/contracts/session_auth/src/lib.rs
@@ -1,0 +1,173 @@
+#![no_std]
+use soroban_sdk::{
+    contract, contractimpl, contracttype, contracterror,
+    Address, Bytes, BytesN, Env, Symbol, Vec,
+};
+
+// ── Storage types ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionData {
+    pub owner:      Address,
+    pub expiry:     u64,
+    pub privileges: Vec<Symbol>,
+}
+
+#[contracttype]
+enum DataKey {
+    Session(BytesN<32>),
+}
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum SessionError {
+    NotFound    = 1,
+    Expired     = 2,
+    Unauthorized = 3,
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct SessionAuth;
+
+#[contractimpl]
+impl SessionAuth {
+    /// Creates a new session for `caller` lasting `duration` seconds.
+    /// Returns the 32-byte session ID derived from the ledger's prng.
+    pub fn create_session(
+        env: Env,
+        caller: Address,
+        duration: u64,
+        privileges: Vec<Symbol>,
+    ) -> BytesN<32> {
+        caller.require_auth();
+
+        // Generate a unique session ID: sha256 of a random 32-byte value
+        let rand: [u8; 32] = env.prng().gen();
+        let session_id: BytesN<32> = env.crypto().sha256(
+            &Bytes::from_slice(&env, &rand)
+        ).into();
+
+        let expiry = env.ledger().timestamp() + duration;
+        let data = SessionData { owner: caller.clone(), expiry, privileges: privileges.clone() };
+        env.storage().persistent().set(&DataKey::Session(session_id.clone()), &data);
+
+        env.events().publish(
+            (Symbol::new(&env, "session"), Symbol::new(&env, "created")),
+            (session_id.clone(), caller),
+        );
+
+        session_id
+    }
+
+    /// Revokes an active session. Only the session owner may revoke.
+    pub fn revoke_session(env: Env, caller: Address, session_id: BytesN<32>) {
+        caller.require_auth();
+
+        let data: SessionData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Session(session_id.clone()))
+            .unwrap_or_else(|| panic_with_error(&env, SessionError::NotFound));
+
+        if data.owner != caller {
+            panic_with_error(&env, SessionError::Unauthorized);
+        }
+
+        env.storage().persistent().remove(&DataKey::Session(session_id.clone()));
+
+        env.events().publish(
+            (Symbol::new(&env, "session"), Symbol::new(&env, "revoked")),
+            (session_id, caller),
+        );
+    }
+
+    /// Returns `true` if the session exists and has not expired.
+    /// Cleans up expired sessions on access.
+    pub fn validate_session(env: Env, session_id: BytesN<32>) -> bool {
+        match env
+            .storage()
+            .persistent()
+            .get::<DataKey, SessionData>(&DataKey::Session(session_id.clone()))
+        {
+            None => false,
+            Some(data) => {
+                if env.ledger().timestamp() >= data.expiry {
+                    // Lazy cleanup: remove expired session
+                    env.storage().persistent().remove(&DataKey::Session(session_id.clone()));
+                    env.events().publish(
+                        (Symbol::new(&env, "session"), Symbol::new(&env, "expired")),
+                        session_id,
+                    );
+                    false
+                } else {
+                    true
+                }
+            }
+        }
+    }
+
+    /// Returns the `SessionData` for a session, panicking if not found or expired.
+    pub fn get_session(env: Env, session_id: BytesN<32>) -> SessionData {
+        let data: SessionData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Session(session_id.clone()))
+            .unwrap_or_else(|| panic_with_error(&env, SessionError::NotFound));
+
+        if env.ledger().timestamp() >= data.expiry {
+            env.storage().persistent().remove(&DataKey::Session(session_id.clone()));
+            env.events().publish(
+                (Symbol::new(&env, "session"), Symbol::new(&env, "expired")),
+                session_id,
+            );
+            panic_with_error(&env, SessionError::Expired);
+        }
+
+        data
+    }
+
+    /// Replaces the privilege list on an active session. Only the owner may call this.
+    pub fn set_privileges(
+        env: Env,
+        caller: Address,
+        session_id: BytesN<32>,
+        new_privileges: Vec<Symbol>,
+    ) {
+        caller.require_auth();
+
+        let mut data: SessionData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Session(session_id.clone()))
+            .unwrap_or_else(|| panic_with_error(&env, SessionError::NotFound));
+
+        if data.owner != caller {
+            panic_with_error(&env, SessionError::Unauthorized);
+        }
+        if env.ledger().timestamp() >= data.expiry {
+            env.storage().persistent().remove(&DataKey::Session(session_id.clone()));
+            panic_with_error(&env, SessionError::Expired);
+        }
+
+        data.privileges = new_privileges.clone();
+        env.storage().persistent().set(&DataKey::Session(session_id.clone()), &data);
+
+        env.events().publish(
+            (Symbol::new(&env, "session"), Symbol::new(&env, "privilege_changed")),
+            (session_id, new_privileges),
+        );
+    }
+}
+
+/// Helper: panic with a `SessionError` value.
+#[inline(never)]
+fn panic_with_error(env: &Env, err: SessionError) -> ! {
+    env.panic_with_error(err)
+}
+
+mod test;

--- a/contracts/session_auth/src/test.rs
+++ b/contracts/session_auth/src/test.rs
@@ -1,0 +1,237 @@
+#![cfg(test)]
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    vec, Address, Env, Symbol,
+};
+
+use crate::{SessionAuth, SessionAuthClient};
+
+fn setup() -> (Env, SessionAuthClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(SessionAuth, ());
+    let client = SessionAuthClient::new(&env, &id);
+    (env, client)
+}
+
+/// Returns true if the most-recently emitted events contain one with the given second topic.
+fn last_event_action(env: &Env) -> Option<Symbol> {
+    use soroban_sdk::TryFromVal;
+    let events = env.events().all();
+    let last = events.last()?;
+    let topics: soroban_sdk::Vec<soroban_sdk::Val> = last.1;
+    if topics.len() < 2 {
+        return None;
+    }
+    let topic1: soroban_sdk::Val = topics.get(1).unwrap();
+    Symbol::try_from_val(env, &topic1).ok()
+}
+
+// ── create_session ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_create_session_emits_created_event() {
+    let (env, client) = setup();
+    let caller = Address::generate(&env);
+    let privs = vec![&env, Symbol::new(&env, "read")];
+    client.create_session(&caller, &3600u64, &privs);
+
+    let action = last_event_action(&env).expect("no event emitted");
+    assert_eq!(action, Symbol::new(&env, "created"));
+}
+
+#[test]
+fn test_create_session_is_immediately_valid() {
+    let (env, client) = setup();
+    let caller = Address::generate(&env);
+    let session_id = client.create_session(&caller, &3600u64, &vec![&env]);
+    assert!(client.validate_session(&session_id));
+}
+
+#[test]
+fn test_create_session_stores_correct_data() {
+    let (env, client) = setup();
+    let caller = Address::generate(&env);
+    env.ledger().set_timestamp(1000);
+
+    let privs = vec![&env, Symbol::new(&env, "admin")];
+    let session_id = client.create_session(&caller, &500u64, &privs);
+
+    let data = client.get_session(&session_id);
+    assert_eq!(data.owner, caller);
+    assert_eq!(data.expiry, 1500u64);
+    assert_eq!(data.privileges, privs);
+}
+
+// ── validate_session ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_validate_session_false_after_expiry() {
+    let (env, client) = setup();
+    let caller = Address::generate(&env);
+    env.ledger().set_timestamp(0);
+
+    let session_id = client.create_session(&caller, &100u64, &vec![&env]);
+    assert!(client.validate_session(&session_id));
+
+    env.ledger().set_timestamp(100);
+    assert!(!client.validate_session(&session_id));
+}
+
+#[test]
+fn test_validate_session_emits_expired_event() {
+    let (env, client) = setup();
+    let caller = Address::generate(&env);
+    env.ledger().set_timestamp(0);
+
+    let session_id = client.create_session(&caller, &50u64, &vec![&env]);
+    env.ledger().set_timestamp(50);
+
+    assert!(!client.validate_session(&session_id));
+
+    let action = last_event_action(&env).expect("no event emitted");
+    assert_eq!(action, Symbol::new(&env, "expired"));
+}
+
+#[test]
+fn test_validate_nonexistent_session_returns_false() {
+    let (env, client) = setup();
+    let fake_id = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    assert!(!client.validate_session(&fake_id));
+}
+
+// ── get_session ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_get_session_panics_when_not_found() {
+    let (env, client) = setup();
+    let fake_id = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
+    assert!(client.try_get_session(&fake_id).is_err());
+}
+
+#[test]
+fn test_get_session_panics_when_expired() {
+    let (env, client) = setup();
+    let caller = Address::generate(&env);
+    env.ledger().set_timestamp(0);
+
+    let session_id = client.create_session(&caller, &10u64, &vec![&env]);
+    env.ledger().set_timestamp(10);
+
+    assert!(client.try_get_session(&session_id).is_err());
+}
+
+// ── revoke_session ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_revoke_session_removes_it() {
+    let (env, client) = setup();
+    let caller = Address::generate(&env);
+
+    let session_id = client.create_session(&caller, &3600u64, &vec![&env]);
+    assert!(client.validate_session(&session_id));
+
+    client.revoke_session(&caller, &session_id);
+    assert!(!client.validate_session(&session_id));
+}
+
+#[test]
+fn test_revoke_session_emits_event() {
+    let (env, client) = setup();
+    let caller = Address::generate(&env);
+
+    let session_id = client.create_session(&caller, &3600u64, &vec![&env]);
+    client.revoke_session(&caller, &session_id);
+
+    let action = last_event_action(&env).expect("no event emitted");
+    assert_eq!(action, Symbol::new(&env, "revoked"));
+}
+
+#[test]
+fn test_revoke_nonexistent_session_panics() {
+    let (env, client) = setup();
+    let caller = Address::generate(&env);
+    let fake_id = soroban_sdk::BytesN::from_array(&env, &[2u8; 32]);
+    assert!(client.try_revoke_session(&caller, &fake_id).is_err());
+}
+
+#[test]
+fn test_revoke_by_non_owner_panics() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    let session_id = client.create_session(&owner, &3600u64, &vec![&env]);
+    assert!(client.try_revoke_session(&attacker, &session_id).is_err());
+}
+
+// ── set_privileges ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_set_privileges_updates_data() {
+    let (env, client) = setup();
+    let caller = Address::generate(&env);
+
+    let session_id = client.create_session(
+        &caller,
+        &3600u64,
+        &vec![&env, Symbol::new(&env, "read")],
+    );
+    let new_privs = vec![&env, Symbol::new(&env, "read"), Symbol::new(&env, "write")];
+    client.set_privileges(&caller, &session_id, &new_privs);
+
+    let data = client.get_session(&session_id);
+    assert_eq!(data.privileges, new_privs);
+}
+
+#[test]
+fn test_set_privileges_emits_event() {
+    let (env, client) = setup();
+    let caller = Address::generate(&env);
+
+    let session_id = client.create_session(&caller, &3600u64, &vec![&env]);
+    let new_privs = vec![&env, Symbol::new(&env, "write")];
+    client.set_privileges(&caller, &session_id, &new_privs);
+
+    let action = last_event_action(&env).expect("no event emitted");
+    assert_eq!(action, Symbol::new(&env, "privilege_changed"));
+}
+
+#[test]
+fn test_set_privileges_by_non_owner_panics() {
+    let (env, client) = setup();
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    let session_id = client.create_session(&owner, &3600u64, &vec![&env]);
+    assert!(client.try_set_privileges(&attacker, &session_id, &vec![&env]).is_err());
+}
+
+#[test]
+fn test_set_privileges_on_expired_session_panics() {
+    let (env, client) = setup();
+    let caller = Address::generate(&env);
+    env.ledger().set_timestamp(0);
+
+    let session_id = client.create_session(&caller, &10u64, &vec![&env]);
+    env.ledger().set_timestamp(10);
+
+    assert!(client.try_set_privileges(&caller, &session_id, &vec![&env]).is_err());
+}
+
+// ── auth enforcement ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_create_session_requires_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(SessionAuth, ());
+    let client = SessionAuthClient::new(&env, &id);
+    let caller = Address::generate(&env);
+
+    client.create_session(&caller, &100u64, &vec![&env]);
+
+    let auths = env.auths();
+    assert!(!auths.is_empty());
+    assert_eq!(auths[0].0, caller);
+}

--- a/contracts/session_auth/test_snapshots/test/test_create_session_emits_created_event.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_create_session_emits_created_event.1.json
@@ -1,0 +1,243 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "3600"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "read"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Session"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Session"
+                    },
+                    {
+                      "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": "3600"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "privileges"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "read"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "session"
+              },
+              {
+                "symbol": "created"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/session_auth/test_snapshots/test/test_create_session_is_immediately_valid.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_create_session_is_immediately_valid.1.json
@@ -1,0 +1,205 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "3600"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Session"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Session"
+                    },
+                    {
+                      "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": "3600"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "privileges"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/session_auth/test_snapshots/test/test_create_session_requires_auth.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_create_session_requires_auth.1.json
@@ -1,0 +1,235 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "100"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Session"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Session"
+                    },
+                    {
+                      "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": "100"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "privileges"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "session"
+              },
+              {
+                "symbol": "created"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/session_auth/test_snapshots/test/test_create_session_returns_id_and_emits_event.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_create_session_returns_id_and_emits_event.1.json
@@ -1,0 +1,219 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "3600"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "read"
+                    },
+                    {
+                      "symbol": "write"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Session"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Session"
+                    },
+                    {
+                      "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": "3600"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "privileges"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "read"
+                          },
+                          {
+                            "symbol": "write"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/session_auth/test_snapshots/test/test_create_session_stores_correct_data.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_create_session_stores_correct_data.1.json
@@ -1,0 +1,213 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "500"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "admin"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 1000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Session"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Session"
+                    },
+                    {
+                      "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": "1500"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "privileges"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "admin"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/session_auth/test_snapshots/test/test_get_session_panics_when_expired.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_get_session_panics_when_expired.1.json
@@ -1,0 +1,229 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "10"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 10,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Session"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Session"
+                    },
+                    {
+                      "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": "10"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "privileges"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "session"
+              },
+              {
+                "symbol": "expired"
+              }
+            ],
+            "data": {
+              "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+            }
+          }
+        }
+      },
+      "failed_call": true
+    }
+  ]
+}

--- a/contracts/session_auth/test_snapshots/test/test_get_session_panics_when_not_found.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_get_session_panics_when_not_found.1.json
@@ -1,0 +1,77 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/session_auth/test_snapshots/test/test_revoke_by_non_owner_panics.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_revoke_by_non_owner_panics.1.json
@@ -1,0 +1,205 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "3600"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Session"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Session"
+                    },
+                    {
+                      "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": "3600"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "privileges"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/session_auth/test_snapshots/test/test_revoke_nonexistent_session_panics.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_revoke_nonexistent_session_panics.1.json
@@ -1,0 +1,77 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/session_auth/test_snapshots/test/test_revoke_session_emits_event.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_revoke_session_emits_event.1.json
@@ -1,0 +1,220 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "3600"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "revoke_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "session"
+              },
+              {
+                "symbol": "revoked"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/session_auth/test_snapshots/test/test_revoke_session_removes_it.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_revoke_session_removes_it.1.json
@@ -1,0 +1,191 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "3600"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "revoke_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/session_auth/test_snapshots/test/test_set_privileges_by_non_owner_panics.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_set_privileges_by_non_owner_panics.1.json
@@ -1,0 +1,205 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "3600"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Session"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Session"
+                    },
+                    {
+                      "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": "3600"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "privileges"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/session_auth/test_snapshots/test/test_set_privileges_emits_event.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_set_privileges_emits_event.1.json
@@ -1,0 +1,305 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "3600"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_privileges",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "write"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Session"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Session"
+                    },
+                    {
+                      "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": "3600"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "privileges"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "write"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "session"
+              },
+              {
+                "symbol": "privilege_changed"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "write"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/session_auth/test_snapshots/test/test_set_privileges_on_expired_session_panics.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_set_privileges_on_expired_session_panics.1.json
@@ -1,0 +1,205 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "10"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 10,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Session"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Session"
+                    },
+                    {
+                      "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": "10"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "privileges"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/session_auth/test_snapshots/test/test_set_privileges_updates_and_emits_event.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_set_privileges_updates_and_emits_event.1.json
@@ -1,0 +1,281 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "3600"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "read"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_privileges",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "read"
+                    },
+                    {
+                      "symbol": "write"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Session"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Session"
+                    },
+                    {
+                      "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": "3600"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "privileges"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "read"
+                          },
+                          {
+                            "symbol": "write"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/session_auth/test_snapshots/test/test_set_privileges_updates_data.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_set_privileges_updates_data.1.json
@@ -1,0 +1,281 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "3600"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "read"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_privileges",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "read"
+                    },
+                    {
+                      "symbol": "write"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Session"
+                },
+                {
+                  "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Session"
+                    },
+                    {
+                      "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "expiry"
+                      },
+                      "val": {
+                        "u64": "3600"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "owner"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "privileges"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "read"
+                          },
+                          {
+                            "symbol": "write"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/session_auth/test_snapshots/test/test_validate_nonexistent_session_returns_false.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_validate_nonexistent_session_returns_false.1.json
@@ -1,0 +1,77 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/contracts/session_auth/test_snapshots/test/test_validate_session_emits_expired_event.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_validate_session_emits_expired_event.1.json
@@ -1,0 +1,159 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "50"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 50,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "session"
+              },
+              {
+                "symbol": "expired"
+              }
+            ],
+            "data": {
+              "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/session_auth/test_snapshots/test/test_validate_session_false_after_expiry.1.json
+++ b/contracts/session_auth/test_snapshots/test/test_validate_session_false_after_expiry.1.json
@@ -1,0 +1,160 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_session",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "u64": "100"
+                },
+                {
+                  "vec": []
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 100,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "session"
+              },
+              {
+                "symbol": "expired"
+              }
+            ],
+            "data": {
+              "bytes": "baec82290b25a5ff98fff42b87dbb04505bcf68787af5d431203f4730634a415"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/docs/session_auth.md
+++ b/docs/session_auth.md
@@ -1,0 +1,134 @@
+# Session Auth Contract
+
+The `SessionAuth` contract provides secure on-chain session management for external DApps integrating with the EventHorizon platform. It allows callers to create time-bounded, privilege-scoped sessions and emits structured events for every lifecycle transition.
+
+## Session Lifecycle
+
+```
+create_session()
+      │
+      ▼
+  [Active] ──── validate_session() ──► true
+      │
+      ├── set_privileges()  ──► privilege_changed event
+      │
+      ├── revoke_session()  ──► revoked event  ──► [Removed]
+      │
+      └── timestamp >= expiry ──► expired event ──► [Removed]
+```
+
+1. **Created** – `create_session` stores a `SessionData` entry in persistent storage and emits a `created` event.
+2. **Active** – `validate_session` returns `true`; `get_session` returns the data; `set_privileges` updates the privilege list.
+3. **Expired** – On any access after `expiry`, the entry is lazily removed and an `expired` event is emitted.
+4. **Revoked** – The owner calls `revoke_session`; the entry is immediately removed and a `revoked` event is emitted.
+
+## Public Functions
+
+### `create_session(caller: Address, duration: u64, privileges: Vec<Symbol>) -> BytesN<32>`
+
+Creates a new session for `caller`.
+
+| Parameter    | Type          | Description                                      |
+|--------------|---------------|--------------------------------------------------|
+| `caller`     | `Address`     | Session owner. `require_auth()` is enforced.     |
+| `duration`   | `u64`         | Session lifetime in seconds from current ledger. |
+| `privileges` | `Vec<Symbol>` | Arbitrary privilege labels for the session.      |
+
+**Returns** a 32-byte session ID (`BytesN<32>`) derived from `sha256(prng_bytes)`.
+
+**Errors** – panics if auth is not provided.
+
+---
+
+### `revoke_session(caller: Address, session_id: BytesN<32>)`
+
+Immediately invalidates a session. Only the session owner may call this.
+
+| Parameter    | Type          | Description                                  |
+|--------------|---------------|----------------------------------------------|
+| `caller`     | `Address`     | Must match `SessionData.owner`.              |
+| `session_id` | `BytesN<32>`  | ID of the session to revoke.                 |
+
+**Errors** – `SessionError::NotFound` (1) if session does not exist; `SessionError::Unauthorized` (3) if caller is not the owner.
+
+---
+
+### `validate_session(session_id: BytesN<32>) -> bool`
+
+Returns `true` if the session exists and has not expired. Performs lazy cleanup on expired sessions (removes storage entry and emits `expired` event).
+
+| Parameter    | Type         | Description              |
+|--------------|--------------|--------------------------|
+| `session_id` | `BytesN<32>` | ID of the session to check. |
+
+**Returns** `false` for unknown or expired sessions; never panics.
+
+---
+
+### `get_session(session_id: BytesN<32>) -> SessionData`
+
+Returns the full `SessionData` for an active session.
+
+| Parameter    | Type         | Description                 |
+|--------------|--------------|-----------------------------|
+| `session_id` | `BytesN<32>` | ID of the session to fetch. |
+
+**Returns** `SessionData { owner, expiry, privileges }`.
+
+**Errors** – `SessionError::NotFound` (1) if not found; `SessionError::Expired` (2) if expired (also cleans up storage and emits `expired` event).
+
+---
+
+### `set_privileges(caller: Address, session_id: BytesN<32>, new_privileges: Vec<Symbol>)`
+
+Replaces the privilege list on an active session. Only the session owner may call this.
+
+| Parameter        | Type          | Description                              |
+|------------------|---------------|------------------------------------------|
+| `caller`         | `Address`     | Must match `SessionData.owner`.          |
+| `session_id`     | `BytesN<32>`  | ID of the session to update.             |
+| `new_privileges` | `Vec<Symbol>` | Replacement privilege list.              |
+
+**Errors** – `SessionError::NotFound` (1), `SessionError::Unauthorized` (3), or `SessionError::Expired` (2).
+
+## Data Structures
+
+### `SessionData`
+
+```rust
+pub struct SessionData {
+    pub owner:      Address,       // Session owner
+    pub expiry:     u64,           // Unix timestamp after which session is invalid
+    pub privileges: Vec<Symbol>,   // Caller-defined privilege labels
+}
+```
+
+### `SessionError`
+
+| Variant       | Value | Meaning                                  |
+|---------------|-------|------------------------------------------|
+| `NotFound`    | 1     | No session exists for the given ID.      |
+| `Expired`     | 2     | Session exists but its expiry has passed.|
+| `Unauthorized`| 3     | Caller is not the session owner.         |
+
+## Events
+
+All events use the topic prefix `"session"` as the first topic.
+
+| Event               | Topics                          | Data                              |
+|---------------------|---------------------------------|-----------------------------------|
+| Session created     | `("session", "created")`        | `(session_id: BytesN<32>, owner: Address)` |
+| Session expired     | `("session", "expired")`        | `session_id: BytesN<32>`          |
+| Session revoked     | `("session", "revoked")`        | `(session_id: BytesN<32>, caller: Address)` |
+| Privilege changed   | `("session", "privilege_changed")` | `(session_id: BytesN<32>, new_privileges: Vec<Symbol>)` |
+
+## Storage Layout
+
+| Key                        | Storage Type | Value        | Lifetime                          |
+|----------------------------|--------------|--------------|-----------------------------------|
+| `DataKey::Session(id)`     | `persistent` | `SessionData`| Until revoked or expiry cleanup   |
+
+**Footprint considerations:**
+- Only active sessions occupy storage. Expired sessions are removed lazily on the first access after expiry (via `validate_session` or `get_session`), keeping the ledger footprint minimal.
+- Each session entry stores one `Address`, one `u64`, and a `Vec<Symbol>`. For typical privilege sets (2–5 symbols), this is well under 256 bytes per entry.
+- No global counters or indexes are maintained; the contract is stateless beyond individual session entries.

--- a/docs/wasm-ops.md
+++ b/docs/wasm-ops.md
@@ -1,0 +1,180 @@
+# LiquifactEscrow Wasm Operations
+
+Runbook for detecting a new LiquifactEscrow wasm deployment and triggering a
+contract list refresh in the EventHorizon backend.
+
+---
+
+## How to detect a new wasm version on-chain
+
+The LiquifactEscrow contract exposes a view function `schema_version()` that
+returns a `u32` integer stored in persistent storage. This integer is the
+**SCHEMA_VERSION** and is incremented with every breaking wasm upgrade.
+
+The backend maintains a local registry in `src/config/escrowVersions.js` that
+maps each known SCHEMA_VERSION to its corresponding semver string:
+
+```js
+const VERSION_REGISTRY = {
+  '1.0.0': 1,
+  '1.1.0': 2,
+  '2.0.0': 3,
+};
+```
+
+A new deployment is detected when the on-chain `schema_version()` return value
+is **greater than** the highest value in `VERSION_REGISTRY`.
+
+### Detection logic
+
+`checkOnChainVersion()` in `src/config/escrowVersions.js`:
+
+1. Calls `schema_version()` via `simulateTransaction` (read-only, no fee).
+2. Compares the result against `latestKnownSchemaVersion()`.
+3. Returns `{ onChainVersion, semver, isLatest, latestKnown }`.
+
+---
+
+## Step-by-step: triggering a contract list refresh after a new wasm deployment
+
+1. **Deploy the new wasm** using the Soroban CLI or your CI pipeline.
+   Confirm the new `SCHEMA_VERSION` is stored on-chain.
+
+2. **Update the registry** in `src/config/escrowVersions.js`:
+   ```js
+   '3.0.0': 4,   // add the new entry
+   ```
+   Commit and deploy the backend.
+
+3. **Trigger the refresh** via the admin endpoint:
+   ```bash
+   curl -X POST https://your-api/api/escrow/refresh \
+     -H "X-Admin-Token: $ADMIN_ACCESS_TOKEN"
+   ```
+   The endpoint reads the on-chain version, compares it to the registry, and
+   sets `refreshTriggered: true` when a newer version is detected.
+
+4. **Verify the response**:
+   ```json
+   {
+     "success": true,
+     "data": {
+       "onChainVersion": 4,
+       "semver": "3.0.0",
+       "isLatest": true,
+       "latestKnown": 4,
+       "refreshTriggered": false
+     }
+   }
+   ```
+   `refreshTriggered: true` means the on-chain version was ahead of the
+   registry at the time of the call (i.e., the registry had not yet been
+   updated).
+
+5. **Downstream action** (extension point in `escrow.routes.js`): when
+   `refreshTriggered` is `true`, the route logs the event. Wire in your own
+   job enqueue or event emission at that point.
+
+---
+
+## Required environment variables
+
+| Variable | Purpose |
+|---|---|
+| `LIQUIFACT_ESCROW_CONTRACT_ID` | Soroban contract address of the deployed LiquifactEscrow |
+| `SOROBAN_RPC_URL` | Soroban RPC endpoint (defaults to testnet if unset) |
+| `NETWORK_PASSPHRASE` | Stellar network passphrase |
+| `ADMIN_ACCESS_TOKEN` | Secret token required in `X-Admin-Token` header for admin endpoints |
+
+---
+
+## Admin endpoint reference
+
+### `POST /api/escrow/refresh`
+
+Reads the on-chain `SCHEMA_VERSION`, compares it to the local registry, and
+returns whether a refresh was triggered.
+
+**Auth**: `X-Admin-Token: <ADMIN_ACCESS_TOKEN>` header required.
+
+**Success response (200)**:
+```json
+{
+  "success": true,
+  "data": {
+    "onChainVersion": 3,
+    "semver": "2.0.0",
+    "isLatest": true,
+    "latestKnown": 3,
+    "refreshTriggered": false
+  }
+}
+```
+
+**Error responses**:
+
+| Status | Condition |
+|---|---|
+| 401 | `X-Admin-Token` header missing |
+| 403 | `X-Admin-Token` value does not match `ADMIN_ACCESS_TOKEN` |
+| 500 | RPC call failed or contract returned an error |
+| 503 | `ADMIN_ACCESS_TOKEN` is not set on the server |
+
+**curl example**:
+```bash
+curl -s -X POST https://your-api/api/escrow/refresh \
+  -H "X-Admin-Token: $ADMIN_ACCESS_TOKEN" | jq .
+```
+
+**OpenAPI**: the endpoint is annotated with `@openapi` JSDoc and appears in
+the Swagger UI at `/api/docs`.
+
+---
+
+## Error handling expectations
+
+- `checkOnChainVersion()` never calls `process.exit`. All errors are thrown
+  as `Error` instances and propagate to the caller.
+- The route handler catches all errors and returns a structured `500` JSON
+  response; it never crashes the process.
+- If `LIQUIFACT_ESCROW_CONTRACT_ID` is unset, `checkOnChainVersion()` throws
+  immediately with a descriptive message before making any network call.
+- RPC timeouts and simulation errors surface as `500` responses with the
+  original error message in `data.error`.
+
+### Rollback steps if refresh fails
+
+1. Check the `500` response body for the error message.
+2. Verify `LIQUIFACT_ESCROW_CONTRACT_ID` and `SOROBAN_RPC_URL` are correct.
+3. Confirm the contract is reachable: `soroban contract invoke --id $CONTRACT_ID -- schema_version`.
+4. If the registry is out of date (new wasm deployed but registry not updated),
+   add the new entry to `VERSION_REGISTRY` and redeploy the backend.
+5. Re-trigger the refresh endpoint once the backend is updated.
+
+---
+
+## Storage layout and footprint
+
+The backend stores **no on-chain state**. All version data lives in:
+
+- `src/config/escrowVersions.js` — in-process registry (zero DB footprint).
+- Application logs — version check results are logged at `info` level.
+
+The `simulateTransaction` call used to read `schema_version()` is read-only
+and does not consume any ledger entries or fees.
+
+---
+
+## Security notes
+
+- **Input validation**: `LIQUIFACT_ESCROW_CONTRACT_ID` is passed directly to
+  the Stellar SDK `Contract` constructor. The SDK validates the address format;
+  invalid addresses throw before any network call is made.
+- **Auth requirements**: the `/api/escrow/refresh` endpoint requires a
+  matching `X-Admin-Token` header. Use a long, randomly generated value for
+  `ADMIN_ACCESS_TOKEN` and restrict the endpoint to internal networks or VPN.
+- **Key handling**: no private keys are used. The version check uses
+  `simulateTransaction` (read-only). No signing keys are required or stored.
+- **No secrets in code**: all sensitive values (`ADMIN_ACCESS_TOKEN`,
+  `LIQUIFACT_ESCROW_CONTRACT_ID`) are read exclusively from `process.env`.
+  Never hardcode them in source files.


### PR DESCRIPTION
 

closes #324 
Implements— version-aware contract list refresh triggered when a new LiquifactEscrow wasm is deployed 
on-chain.
  
  ## Changes
  
  ### `backend/src/config/escrowVersions.js` (new)
  - `VERSION_REGISTRY` — frozen semver → SCHEMA_VERSION mapping for all known LiquifactEscrow deployments
  - `semverForSchemaVersion(sv)` — reverse registry lookup
  - `latestKnownSchemaVersion()` — returns the highest known SCHEMA_VERSION
  - `checkOnChainVersion(deps?)` — reads `schema_version()` from the contract via `simulateTransaction` (read-only, no fee), compares to registry, returns
  `{ onChainVersion, semver, isLatest, latestKnown }`. Injectable dep for testing. Never calls `process.exit`; all errors thrown.
  
  ### `backend/src/routes/escrow.routes.js` (new)
  - `adminAuth` middleware — `X-Admin-Token` / `ADMIN_ACCESS_TOKEN` pattern, consistent with existing audit routes (401 missing, 403 wrong, 503 not
  configured)
  - `POST /api/escrow/refresh` — admin-only endpoint that triggers the version check and returns `refreshTriggered: true` when the on-chain version is
  ahead of the registry
  
  ### `backend/src/app.js`
  - One line: `app.use('/api/escrow', require('./routes/escrow.routes'))`
  
  ### `backend/__tests__/escrowVersions.test.js` (new)
  15 tests using `node:test` (matching the existing test runner):
  - Registry shape and lookup logic
  - `checkOnChainVersion` with mocked chain reads (known version, older version, unregistered version, error propagation, missing env var)
  - Route auth: 401 missing token, 403 wrong token, 503 unconfigured
  - Route success path and 500 error path
  
  ### `docs/wasm-ops.md` (new)
  Full runbook: detection procedure, step-by-step refresh workflow, required env vars, error handling, rollback steps, curl examples, security notes.
  
  ## Required environment variables
  
  | Variable | Purpose |
  |---|---|
  | `LIQUIFACT_ESCROW_CONTRACT_ID` | Soroban contract address |
  | `SOROBAN_RPC_URL` | RPC endpoint (defaults to testnet) |
  | `NETWORK_PASSPHRASE` | Stellar network passphrase |
  | `ADMIN_ACCESS_TOKEN` | Secret for `X-Admin-Token` header |
  
  ## Testing
  
  node --test backend/tests/escrowVersions.test.js
  # tests 15 | pass 15 | fail 0