### PR TITLE
feat: on-chain Task Scheduler Soroban contract

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "emitter_registry",
     "flash_loan",
     "royalty_registry",
+    "task_scheduler",
 ]
 
 [profile.release]

--- a/contracts/task_scheduler/Cargo.toml
+++ b/contracts/task_scheduler/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "task_scheduler"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "23.4.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "23.4.0", features = ["testutils"] }

--- a/contracts/task_scheduler/src/lib.rs
+++ b/contracts/task_scheduler/src/lib.rs
@@ -1,0 +1,171 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env, Symbol, Vec};
+
+// ── Storage types ────────────────────────────────────────────────────────────
+
+/// Status of a task in the queue.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TaskStatus {
+    Pending,
+    Cancelled,
+}
+
+/// A scheduled task.
+#[contracttype]
+#[derive(Clone)]
+pub struct Task {
+    pub id: u64,
+    pub owner: Address,
+    /// Ledger timestamp at or after which the task should be executed.
+    pub trigger_at: u64,
+    /// Arbitrary payload forwarded verbatim in the event for the off-chain worker.
+    pub payload: Bytes,
+    pub status: TaskStatus,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    /// Monotonic task-id counter (instance).
+    NextId,
+    /// Task record (persistent).
+    Task(u64),
+    /// List of task ids owned by an address (persistent).
+    OwnerTasks(Address),
+}
+
+// ── Contract ─────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct TaskScheduler;
+
+#[contractimpl]
+impl TaskScheduler {
+    /// Register a new task.
+    ///
+    /// * `trigger_at` – ledger timestamp when the task should fire.
+    /// * `payload`    – opaque bytes forwarded to the off-chain worker via event.
+    ///
+    /// Returns the new task id.
+    pub fn schedule(env: Env, owner: Address, trigger_at: u64, payload: Bytes) -> u64 {
+        owner.require_auth();
+
+        let now = env.ledger().timestamp();
+        if trigger_at <= now {
+            panic!("trigger_at must be in the future");
+        }
+
+        let id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextId)
+            .unwrap_or(0u64);
+
+        let task = Task {
+            id,
+            owner: owner.clone(),
+            trigger_at,
+            payload: payload.clone(),
+            status: TaskStatus::Pending,
+        };
+
+        env.storage().persistent().set(&DataKey::Task(id), &task);
+
+        // Append to owner index
+        let mut ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OwnerTasks(owner.clone()))
+            .unwrap_or(Vec::new(&env));
+        ids.push_back(id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::OwnerTasks(owner.clone()), &ids);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::NextId, &(id + 1));
+
+        env.events().publish(
+            (Symbol::new(&env, "task_scheduled"), owner),
+            (id, trigger_at, payload),
+        );
+
+        id
+    }
+
+    /// Bump (reschedule) a pending task to a new `trigger_at`.
+    pub fn bump(env: Env, owner: Address, task_id: u64, new_trigger_at: u64) {
+        owner.require_auth();
+
+        let mut task: Task = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Task(task_id))
+            .expect("Task not found");
+
+        if task.owner != owner {
+            panic!("Not task owner");
+        }
+        if task.status != TaskStatus::Pending {
+            panic!("Task is not pending");
+        }
+        let now = env.ledger().timestamp();
+        if new_trigger_at <= now {
+            panic!("new_trigger_at must be in the future");
+        }
+
+        task.trigger_at = new_trigger_at;
+        env.storage().persistent().set(&DataKey::Task(task_id), &task);
+
+        env.events().publish(
+            (Symbol::new(&env, "task_bumped"), owner),
+            (task_id, new_trigger_at, task.payload),
+        );
+    }
+
+    /// Cancel a pending task.
+    pub fn cancel(env: Env, owner: Address, task_id: u64) {
+        owner.require_auth();
+
+        let mut task: Task = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Task(task_id))
+            .expect("Task not found");
+
+        if task.owner != owner {
+            panic!("Not task owner");
+        }
+        if task.status != TaskStatus::Pending {
+            panic!("Task is not pending");
+        }
+
+        task.status = TaskStatus::Cancelled;
+        env.storage().persistent().set(&DataKey::Task(task_id), &task);
+
+        env.events().publish(
+            (Symbol::new(&env, "task_cancelled"), owner),
+            (task_id, task.payload),
+        );
+    }
+
+    /// Fetch a single task by id.
+    pub fn get_task(env: Env, task_id: u64) -> Task {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Task(task_id))
+            .expect("Task not found")
+    }
+
+    /// Return all task ids registered by `owner`.
+    pub fn get_owner_tasks(env: Env, owner: Address) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::OwnerTasks(owner))
+            .unwrap_or(Vec::new(&env))
+    }
+}
+
+mod test;

--- a/contracts/task_scheduler/src/test.rs
+++ b/contracts/task_scheduler/src/test.rs
@@ -1,0 +1,127 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::{testutils::{Address as _, Ledger}, Bytes, Env};
+
+fn setup() -> (Env, Address, TaskSchedulerClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    // Start at a non-zero timestamp so "future" checks work
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+    let owner = Address::generate(&env);
+    let contract_id = env.register(TaskScheduler, ());
+    let client = TaskSchedulerClient::new(&env, &contract_id);
+    (env, owner, client)
+}
+
+#[test]
+fn test_schedule_and_get() {
+    let (env, owner, client) = setup();
+    let payload = Bytes::from_slice(&env, b"run_job_42");
+
+    let id = client.schedule(&owner, &2000, &payload);
+    assert_eq!(id, 0);
+
+    let task = client.get_task(&id);
+    assert_eq!(task.id, 0);
+    assert_eq!(task.owner, owner);
+    assert_eq!(task.trigger_at, 2000);
+    assert_eq!(task.payload, payload);
+    assert_eq!(task.status, TaskStatus::Pending);
+}
+
+#[test]
+fn test_schedule_increments_id() {
+    let (env, owner, client) = setup();
+    let p = Bytes::from_slice(&env, b"x");
+    let id0 = client.schedule(&owner, &2000, &p);
+    let id1 = client.schedule(&owner, &3000, &p);
+    assert_eq!(id0, 0);
+    assert_eq!(id1, 1);
+}
+
+#[test]
+fn test_get_owner_tasks() {
+    let (env, owner, client) = setup();
+    let p = Bytes::from_slice(&env, b"x");
+    client.schedule(&owner, &2000, &p);
+    client.schedule(&owner, &3000, &p);
+
+    let ids = client.get_owner_tasks(&owner);
+    assert_eq!(ids.len(), 2);
+    assert_eq!(ids.get(0).unwrap(), 0);
+    assert_eq!(ids.get(1).unwrap(), 1);
+}
+
+#[test]
+fn test_bump_updates_trigger_at() {
+    let (env, owner, client) = setup();
+    let p = Bytes::from_slice(&env, b"x");
+    let id = client.schedule(&owner, &2000, &p);
+
+    client.bump(&owner, &id, &5000);
+
+    let task = client.get_task(&id);
+    assert_eq!(task.trigger_at, 5000);
+    assert_eq!(task.status, TaskStatus::Pending);
+}
+
+#[test]
+fn test_cancel_marks_cancelled() {
+    let (env, owner, client) = setup();
+    let p = Bytes::from_slice(&env, b"x");
+    let id = client.schedule(&owner, &2000, &p);
+
+    client.cancel(&owner, &id);
+
+    let task = client.get_task(&id);
+    assert_eq!(task.status, TaskStatus::Cancelled);
+}
+
+#[test]
+#[should_panic(expected = "Task is not pending")]
+fn test_bump_cancelled_task_panics() {
+    let (env, owner, client) = setup();
+    let p = Bytes::from_slice(&env, b"x");
+    let id = client.schedule(&owner, &2000, &p);
+    client.cancel(&owner, &id);
+    client.bump(&owner, &id, &5000);
+}
+
+#[test]
+#[should_panic(expected = "Task is not pending")]
+fn test_cancel_already_cancelled_panics() {
+    let (env, owner, client) = setup();
+    let p = Bytes::from_slice(&env, b"x");
+    let id = client.schedule(&owner, &2000, &p);
+    client.cancel(&owner, &id);
+    client.cancel(&owner, &id);
+}
+
+#[test]
+#[should_panic(expected = "trigger_at must be in the future")]
+fn test_schedule_past_trigger_panics() {
+    let (env, owner, client) = setup();
+    let p = Bytes::from_slice(&env, b"x");
+    // timestamp is 1000, scheduling at 500 should panic
+    client.schedule(&owner, &500, &p);
+}
+
+#[test]
+#[should_panic(expected = "Not task owner")]
+fn test_cancel_by_non_owner_panics() {
+    let (env, owner, client) = setup();
+    let other = Address::generate(&env);
+    let p = Bytes::from_slice(&env, b"x");
+    let id = client.schedule(&owner, &2000, &p);
+    client.cancel(&other, &id);
+}
+
+#[test]
+#[should_panic(expected = "Not task owner")]
+fn test_bump_by_non_owner_panics() {
+    let (env, owner, client) = setup();
+    let other = Address::generate(&env);
+    let p = Bytes::from_slice(&env, b"x");
+    let id = client.schedule(&owner, &2000, &p);
+    client.bump(&other, &id, &5000);
+}


### PR DESCRIPTION
## Summary

Implements the on-chain task scheduler requested in #209.

### New contract: `contracts/task_scheduler`

| File | Purpose |
|------|---------|
| `Cargo.toml` | Package manifest (soroban-sdk 23.4.0) |
| `src/lib.rs` | Contract implementation |
| `src/test.rs` | 10 unit tests |

Also adds `task_scheduler` to the workspace `contracts/Cargo.toml`.

---

## Design

### Storage layout (gas-efficient mapping)

| Key | Storage tier | Value |
|-----|-------------|-------|
| `NextId` | Instance | `u64` monotonic counter |
| `Task(id)` | Persistent | Full `Task` struct |
| `OwnerTasks(addr)` | Persistent | `Vec<u64>` of task ids |

O(1) task lookup by id. No linked-list pointer chasing — a flat mapping is cheaper on Soroban because each storage entry is independently priced and there are no pointer-update side effects.

### Task struct

```rust
pub struct Task {
    pub id: u64,
    pub owner: Address,
    pub trigger_at: u64,   // ledger timestamp
    pub payload: Bytes,    // opaque — forwarded verbatim in events
    pub status: TaskStatus, // Pending | Cancelled
}
```

### Contract functions

| Function | Auth | Description |
|----------|------|-------------|
| `schedule(owner, trigger_at, payload)` | owner | Register a new task; returns task id |
| `bump(owner, task_id, new_trigger_at)` | owner | Reschedule a pending task |
| `cancel(owner, task_id)` | owner | Cancel a pending task |
| `get_task(task_id)` | — | Read a task by id |
| `get_owner_tasks(owner)` | — | List all task ids for an owner |

### Events (full payload included for off-chain worker)

| Topic | Data |
|-------|------|
| `(task_scheduled, owner)` | `(id, trigger_at, payload)` |
| `(task_bumped, owner)` | `(task_id, new_trigger_at, payload)` |
| `(task_cancelled, owner)` | `(task_id, payload)` |

---

## Tests

10 tests covering:
- Schedule and retrieve a task
- ID auto-increment
- Owner task index
- Bump updates `trigger_at`
- Cancel sets `Cancelled` status
- Panic: bump a cancelled task
- Panic: cancel an already-cancelled task
- Panic: `trigger_at` in the past
- Panic: cancel by non-owner
- Panic: bump by non-owner

Closes #209