### PR TITLE
feat: DLQ Management – failed action collection, re-drive API & purge (#261)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -27,6 +27,7 @@ app.use('/api/invitations', require('./routes/invitation.routes'));
 // app.use('/api/team', require('./routes/team.routes'));
 app.use('/api/queue', require('./routes/queue.routes'));
 app.use('/api/discovery', require('./routes/discovery.routes'));
+app.use('/api/dlq', require('./routes/dlq.routes'));
 /**
  * @openapi
  * /api/health:

--- a/backend/src/controllers/dlq.controller.js
+++ b/backend/src/controllers/dlq.controller.js
@@ -1,0 +1,67 @@
+const dlqService = require('../services/dlq.service');
+const logger = require('../config/logger');
+
+async function getStats(req, res) {
+    try {
+        const stats = await dlqService.getStats();
+        res.json({ success: true, data: stats });
+    } catch (err) {
+        logger.error('DLQ getStats failed', { error: err.message });
+        res.status(500).json({ success: false, error: 'Failed to retrieve DLQ statistics' });
+    }
+}
+
+async function listEntries(req, res) {
+    try {
+        const { status, triggerId, page = 1, limit = 50 } = req.query;
+        const result = await dlqService.listFailures({
+            status,
+            triggerId,
+            page: Number(page),
+            limit: Math.min(Number(limit), 200),
+        });
+        res.json({ success: true, data: result });
+    } catch (err) {
+        logger.error('DLQ listEntries failed', { error: err.message });
+        res.status(500).json({ success: false, error: 'Failed to list DLQ entries' });
+    }
+}
+
+async function redriveOne(req, res) {
+    try {
+        const entry = await dlqService.redriveOne(req.params.id);
+        res.json({ success: true, data: entry });
+    } catch (err) {
+        const status = err.statusCode || 500;
+        logger.error('DLQ redriveOne failed', { id: req.params.id, error: err.message });
+        res.status(status).json({ success: false, error: err.message });
+    }
+}
+
+async function redriveAll(req, res) {
+    try {
+        const { triggerId } = req.query;
+        const result = await dlqService.redriveAll({ triggerId });
+        res.json({ success: true, data: result });
+    } catch (err) {
+        logger.error('DLQ redriveAll failed', { error: err.message });
+        res.status(500).json({ success: false, error: 'Failed to re-drive DLQ entries' });
+    }
+}
+
+async function purge(req, res) {
+    try {
+        const { status = 'pending', triggerId, olderThanMs } = req.body || {};
+        const result = await dlqService.purge({
+            status,
+            triggerId,
+            olderThanMs: olderThanMs ? Number(olderThanMs) : undefined,
+        });
+        res.json({ success: true, data: result });
+    } catch (err) {
+        logger.error('DLQ purge failed', { error: err.message });
+        res.status(500).json({ success: false, error: 'Failed to purge DLQ entries' });
+    }
+}
+
+module.exports = { getStats, listEntries, redriveOne, redriveAll, purge };

--- a/backend/src/models/failedAction.model.js
+++ b/backend/src/models/failedAction.model.js
@@ -1,0 +1,53 @@
+const mongoose = require('mongoose');
+
+/**
+ * Dead Letter Queue (DLQ) - persists failed action attempts for later re-driving.
+ */
+const failedActionSchema = new mongoose.Schema(
+    {
+        triggerId: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Trigger',
+            required: true,
+            index: true,
+        },
+        triggerSnapshot: {
+            type: mongoose.Schema.Types.Mixed,
+            required: true,
+        },
+        eventPayload: {
+            type: mongoose.Schema.Types.Mixed,
+            required: true,
+        },
+        errorMessage: {
+            type: String,
+            required: true,
+        },
+        attemptsMade: {
+            type: Number,
+            default: 1,
+        },
+        status: {
+            type: String,
+            enum: ['pending', 'redriving', 'resolved', 'purged'],
+            default: 'pending',
+            index: true,
+        },
+        resolvedAt: {
+            type: Date,
+        },
+        jobId: {
+            type: String,
+            index: true,
+        },
+    },
+    {
+        timestamps: true,
+        collection: 'failed_actions',
+    }
+);
+
+failedActionSchema.index({ createdAt: -1 });
+failedActionSchema.index({ status: 1, createdAt: -1 });
+
+module.exports = mongoose.model('FailedAction', failedActionSchema);

--- a/backend/src/routes/dlq.routes.js
+++ b/backend/src/routes/dlq.routes.js
@@ -1,0 +1,161 @@
+const express = require('express');
+const router = express.Router();
+const dlqController = require('../controllers/dlq.controller');
+
+/**
+ * @openapi
+ * tags:
+ *   - name: DLQ
+ *     description: Dead Letter Queue management – inspect, re-drive, and purge failed action attempts.
+ */
+
+/**
+ * @openapi
+ * /api/dlq/stats:
+ *   get:
+ *     summary: Get DLQ statistics
+ *     tags: [DLQ]
+ *     responses:
+ *       200:
+ *         description: DLQ statistics
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     pending:   { type: integer }
+ *                     redriving: { type: integer }
+ *                     resolved:  { type: integer }
+ *                     purged:    { type: integer }
+ *                     total:     { type: integer }
+ */
+router.get('/stats', dlqController.getStats);
+
+/**
+ * @openapi
+ * /api/dlq/entries:
+ *   get:
+ *     summary: List DLQ entries
+ *     tags: [DLQ]
+ *     parameters:
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [pending, redriving, resolved, purged]
+ *       - in: query
+ *         name: triggerId
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 50
+ *     responses:
+ *       200:
+ *         description: Paginated list of DLQ entries
+ */
+router.get('/entries', dlqController.listEntries);
+
+/**
+ * @openapi
+ * /api/dlq/entries/{id}/redrive:
+ *   post:
+ *     summary: Re-drive a single DLQ entry
+ *     tags: [DLQ]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Entry re-driven successfully
+ *       404:
+ *         description: Entry not found
+ *       409:
+ *         description: Entry is not in pending state
+ */
+router.post('/entries/:id/redrive', dlqController.redriveOne);
+
+/**
+ * @openapi
+ * /api/dlq/redrive-all:
+ *   post:
+ *     summary: Re-drive all pending DLQ entries
+ *     tags: [DLQ]
+ *     parameters:
+ *       - in: query
+ *         name: triggerId
+ *         schema:
+ *           type: string
+ *         description: Optional – limit to a specific trigger
+ *     responses:
+ *       200:
+ *         description: Retry-all results
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     total:     { type: integer }
+ *                     succeeded: { type: integer }
+ *                     failed:    { type: integer }
+ *                     failures:  { type: array, items: { type: object } }
+ */
+router.post('/redrive-all', dlqController.redriveAll);
+
+/**
+ * @openapi
+ * /api/dlq/purge:
+ *   post:
+ *     summary: Purge DLQ entries
+ *     tags: [DLQ]
+ *     requestBody:
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               status:
+ *                 type: string
+ *                 enum: [pending, resolved, purged]
+ *                 default: pending
+ *               triggerId:
+ *                 type: string
+ *               olderThanMs:
+ *                 type: integer
+ *                 description: Only purge entries older than this many milliseconds
+ *     responses:
+ *       200:
+ *         description: Purge result
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean }
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     purged: { type: integer }
+ */
+router.post('/purge', dlqController.purge);
+
+module.exports = router;

--- a/backend/src/services/dlq.service.js
+++ b/backend/src/services/dlq.service.js
@@ -1,0 +1,122 @@
+const FailedAction = require('../models/failedAction.model');
+const logger = require('../config/logger');
+
+/**
+ * Record a failed action attempt into the DLQ collection.
+ */
+async function recordFailure({ triggerId, triggerSnapshot, eventPayload, errorMessage, attemptsMade = 1, jobId }) {
+    const entry = await FailedAction.create({
+        triggerId,
+        triggerSnapshot,
+        eventPayload,
+        errorMessage,
+        attemptsMade,
+        jobId,
+        status: 'pending',
+    });
+    logger.warn('Action recorded in DLQ', { dlqId: entry._id, triggerId, errorMessage });
+    return entry;
+}
+
+/**
+ * List DLQ entries with optional status filter and pagination.
+ */
+async function listFailures({ status, triggerId, page = 1, limit = 50 } = {}) {
+    const filter = {};
+    if (status) filter.status = status;
+    if (triggerId) filter.triggerId = triggerId;
+
+    const skip = (page - 1) * limit;
+    const [items, total] = await Promise.all([
+        FailedAction.find(filter).sort({ createdAt: -1 }).skip(skip).limit(limit).lean(),
+        FailedAction.countDocuments(filter),
+    ]);
+
+    return { items, total, page, limit };
+}
+
+/**
+ * Re-drive a single DLQ entry by re-enqueuing its action.
+ */
+async function redriveOne(dlqId) {
+    const entry = await FailedAction.findById(dlqId);
+    if (!entry) throw Object.assign(new Error('DLQ entry not found'), { statusCode: 404 });
+    if (entry.status !== 'pending') {
+        throw Object.assign(new Error(`Entry is not in pending state (current: ${entry.status})`), { statusCode: 409 });
+    }
+
+    entry.status = 'redriving';
+    await entry.save();
+
+    try {
+        const { enqueueAction } = require('../worker/queue');
+        await enqueueAction(entry.triggerSnapshot, entry.eventPayload);
+        entry.status = 'resolved';
+        entry.resolvedAt = new Date();
+        await entry.save();
+        logger.info('DLQ entry re-driven successfully', { dlqId });
+        return entry;
+    } catch (err) {
+        entry.status = 'pending';
+        await entry.save();
+        throw err;
+    }
+}
+
+/**
+ * Re-drive all pending DLQ entries (optionally filtered by triggerId).
+ */
+async function redriveAll({ triggerId } = {}) {
+    const filter = { status: 'pending' };
+    if (triggerId) filter.triggerId = triggerId;
+
+    const entries = await FailedAction.find(filter).lean();
+    const results = { total: entries.length, succeeded: 0, failed: 0, failures: [] };
+
+    const { enqueueAction } = require('../worker/queue');
+
+    for (const entry of entries) {
+        try {
+            await FailedAction.findByIdAndUpdate(entry._id, { status: 'redriving' });
+            await enqueueAction(entry.triggerSnapshot, entry.eventPayload);
+            await FailedAction.findByIdAndUpdate(entry._id, { status: 'resolved', resolvedAt: new Date() });
+            results.succeeded++;
+        } catch (err) {
+            await FailedAction.findByIdAndUpdate(entry._id, { status: 'pending' });
+            results.failed++;
+            results.failures.push({ id: entry._id, error: err.message });
+            logger.error('Failed to re-drive DLQ entry', { dlqId: entry._id, error: err.message });
+        }
+    }
+
+    logger.info('DLQ retry-all completed', results);
+    return results;
+}
+
+/**
+ * Purge (mark as purged) DLQ entries. Optionally filter by status or triggerId.
+ */
+async function purge({ status = 'pending', triggerId, olderThanMs } = {}) {
+    const filter = { status };
+    if (triggerId) filter.triggerId = triggerId;
+    if (olderThanMs) filter.createdAt = { $lt: new Date(Date.now() - olderThanMs) };
+
+    const result = await FailedAction.updateMany(filter, { status: 'purged' });
+    logger.info('DLQ purge completed', { matched: result.matchedCount });
+    return { purged: result.matchedCount };
+}
+
+/**
+ * Get DLQ statistics.
+ */
+async function getStats() {
+    const counts = await FailedAction.aggregate([
+        { $group: { _id: '$status', count: { $sum: 1 } } },
+    ]);
+    const stats = { pending: 0, redriving: 0, resolved: 0, purged: 0 };
+    for (const { _id, count } of counts) stats[_id] = count;
+    stats.total = Object.values(stats).reduce((a, b) => a + b, 0);
+    return stats;
+}
+
+module.exports = { recordFailure, listFailures, redriveOne, redriveAll, purge, getStats };

--- a/backend/src/worker/poller.js
+++ b/backend/src/worker/poller.js
@@ -276,6 +276,19 @@ async function pollEvents() {
                                         error: error.message,
                                         eventLedger: event.ledger,
                                     });
+                                    // Record in DLQ for later re-driving
+                                    try {
+                                        const dlqService = require('../services/dlq.service');
+                                        await dlqService.recordFailure({
+                                            triggerId: trigger._id,
+                                            triggerSnapshot: trigger.toObject ? trigger.toObject() : trigger,
+                                            eventPayload: event,
+                                            errorMessage: error.message,
+                                            attemptsMade: (trigger.retryConfig?.maxRetries || 3) + 1,
+                                        });
+                                    } catch (dlqErr) {
+                                        logger.error('Failed to record failure in DLQ', { error: dlqErr.message });
+                                    }
                                 }
                             }
                         }

--- a/backend/test/dlq.test.js
+++ b/backend/test/dlq.test.js
@@ -1,0 +1,190 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// ── Minimal mongoose stub ──────────────────────────────────────────────────
+const savedDocs = [];
+let idCounter = 1;
+
+function makeDoc(data) {
+    const doc = {
+        ...data,
+        _id: String(idCounter++),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        save: async function () { return this; },
+        toObject: function () { return { ...this }; },
+    };
+    savedDocs.push(doc);
+    return doc;
+}
+
+// Stub FailedAction model
+const FailedAction = {
+    _docs: savedDocs,
+    create: async (data) => makeDoc(data),
+    find: (filter = {}) => {
+        const filtered = () => savedDocs.filter(d => {
+            if (filter.status && d.status !== filter.status) return false;
+            if (filter.triggerId && d.triggerId !== filter.triggerId) return false;
+            return true;
+        });
+        const chain = {
+            sort: () => chain,
+            skip: () => chain,
+            limit: () => chain,
+            lean: async () => filtered(),
+        };
+        // also support .lean() directly (used by redriveAll)
+        chain.lean = async () => filtered();
+        return chain;
+    },
+    countDocuments: async (filter = {}) => {
+        return savedDocs.filter(d => {
+            if (filter.status && d.status !== filter.status) return false;
+            return true;
+        }).length;
+    },
+    findById: async (id) => savedDocs.find(d => d._id === id) || null,
+    findByIdAndUpdate: async (id, update) => {
+        const doc = savedDocs.find(d => d._id === id);
+        if (doc) Object.assign(doc, update.$set || update);
+        return doc;
+    },
+    aggregate: async (pipeline) => {
+        const groups = {};
+        for (const doc of savedDocs) {
+            groups[doc.status] = (groups[doc.status] || 0) + 1;
+        }
+        return Object.entries(groups).map(([_id, count]) => ({ _id, count }));
+    },
+    updateMany: async (filter, update) => {
+        let matched = 0;
+        for (const doc of savedDocs) {
+            if (filter.status && doc.status !== filter.status) continue;
+            if (filter.triggerId && doc.triggerId !== filter.triggerId) continue;
+            Object.assign(doc, update.$set || update);
+            matched++;
+        }
+        return { matchedCount: matched };
+    },
+};
+
+// Stub queue
+const enqueuedJobs = [];
+const queueStub = {
+    enqueueAction: async (trigger, payload) => {
+        enqueuedJobs.push({ trigger, payload });
+    },
+};
+
+// Patch require for isolated unit tests
+const Module = require('module');
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+    if (request === '../models/failedAction.model' || request.endsWith('failedAction.model')) {
+        return FailedAction;
+    }
+    if (request === '../worker/queue' || request.endsWith('worker/queue')) {
+        return queueStub;
+    }
+    return originalLoad.apply(this, arguments);
+};
+
+const dlqService = require('../src/services/dlq.service');
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+test('recordFailure creates a pending DLQ entry', async () => {
+    const entry = await dlqService.recordFailure({
+        triggerId: 'trigger-1',
+        triggerSnapshot: { actionType: 'webhook' },
+        eventPayload: { ledger: 100 },
+        errorMessage: 'Connection refused',
+        attemptsMade: 3,
+    });
+
+    assert.equal(entry.status, 'pending');
+    assert.equal(entry.triggerId, 'trigger-1');
+    assert.equal(entry.errorMessage, 'Connection refused');
+    assert.equal(entry.attemptsMade, 3);
+});
+
+test('listFailures returns paginated results', async () => {
+    const result = await dlqService.listFailures({ status: 'pending', page: 1, limit: 10 });
+    assert.ok(Array.isArray(result.items));
+    assert.ok(typeof result.total === 'number');
+    assert.equal(result.page, 1);
+    assert.equal(result.limit, 10);
+});
+
+test('redriveOne re-enqueues a pending entry and marks it resolved', async () => {
+    const entry = await dlqService.recordFailure({
+        triggerId: 'trigger-2',
+        triggerSnapshot: { actionType: 'webhook' },
+        eventPayload: { ledger: 200 },
+        errorMessage: 'Timeout',
+    });
+
+    const before = enqueuedJobs.length;
+    const result = await dlqService.redriveOne(entry._id);
+
+    assert.equal(result.status, 'resolved');
+    assert.ok(result.resolvedAt instanceof Date);
+    assert.equal(enqueuedJobs.length, before + 1);
+});
+
+test('redriveOne throws 404 for unknown id', async () => {
+    await assert.rejects(
+        () => dlqService.redriveOne('nonexistent-id'),
+        (err) => {
+            assert.equal(err.statusCode, 404);
+            return true;
+        }
+    );
+});
+
+test('redriveAll re-drives all pending entries', async () => {
+    // Add two more pending entries
+    await dlqService.recordFailure({
+        triggerId: 'trigger-3',
+        triggerSnapshot: {},
+        eventPayload: {},
+        errorMessage: 'err',
+    });
+    await dlqService.recordFailure({
+        triggerId: 'trigger-3',
+        triggerSnapshot: {},
+        eventPayload: {},
+        errorMessage: 'err2',
+    });
+
+    const result = await dlqService.redriveAll({ triggerId: 'trigger-3' });
+    assert.ok(result.total >= 2);
+    assert.equal(result.failed, 0);
+    assert.ok(result.succeeded >= 2);
+});
+
+test('purge marks matching entries as purged', async () => {
+    await dlqService.recordFailure({
+        triggerId: 'trigger-purge',
+        triggerSnapshot: {},
+        eventPayload: {},
+        errorMessage: 'to be purged',
+    });
+
+    const result = await dlqService.purge({ status: 'pending', triggerId: 'trigger-purge' });
+    assert.ok(result.purged >= 1);
+});
+
+test('getStats returns counts per status', async () => {
+    const stats = await dlqService.getStats();
+    assert.ok(typeof stats.pending === 'number');
+    assert.ok(typeof stats.resolved === 'number');
+    assert.ok(typeof stats.purged === 'number');
+    assert.ok(typeof stats.total === 'number');
+});
+
+// Restore
+test.after(() => {
+    Module._load = originalLoad;
+});

--- a/docs/dlq.md
+++ b/docs/dlq.md
@@ -1,0 +1,121 @@
+# Dead Letter Queue (DLQ) Management
+
+EventHorizon automatically captures failed action attempts in a dedicated **Dead Letter Queue** collection, enabling operators to inspect, re-drive, and purge failures without data loss.
+
+## Overview
+
+When a trigger action fails (after all retries are exhausted), the failure is persisted in the `failed_actions` MongoDB collection. Each entry stores:
+
+| Field | Description |
+|---|---|
+| `triggerId` | Reference to the originating trigger |
+| `triggerSnapshot` | Full trigger config at the time of failure |
+| `eventPayload` | The Soroban event that triggered the action |
+| `errorMessage` | The error that caused the failure |
+| `attemptsMade` | Number of attempts before landing in DLQ |
+| `status` | `pending` → `redriving` → `resolved` / `purged` |
+| `jobId` | BullMQ job ID (if queue was used) |
+| `createdAt` | Timestamp of failure |
+
+## Status Lifecycle
+
+```
+pending  ──redrive──►  redriving  ──success──►  resolved
+   │                       │
+   │                    failure
+   │                       │
+   └──────────────────────►┘ (reset to pending)
+   │
+   └──purge──►  purged
+```
+
+## API Endpoints
+
+All endpoints are under `/api/dlq`.
+
+### GET `/api/dlq/stats`
+
+Returns counts per status.
+
+```json
+{
+  "success": true,
+  "data": {
+    "pending": 12,
+    "redriving": 0,
+    "resolved": 45,
+    "purged": 3,
+    "total": 60
+  }
+}
+```
+
+### GET `/api/dlq/entries`
+
+List DLQ entries with optional filtering and pagination.
+
+**Query parameters:**
+
+| Param | Type | Description |
+|---|---|---|
+| `status` | string | Filter by status: `pending`, `redriving`, `resolved`, `purged` |
+| `triggerId` | string | Filter by trigger ObjectId |
+| `page` | integer | Page number (default: 1) |
+| `limit` | integer | Page size, max 200 (default: 50) |
+
+### POST `/api/dlq/entries/:id/redrive`
+
+Re-drive a single pending DLQ entry. The entry's action is re-enqueued via BullMQ and the status transitions to `resolved` on success.
+
+Returns `409` if the entry is not in `pending` state.
+
+### POST `/api/dlq/redrive-all`
+
+Re-drive **all** pending entries. Optionally scope to a single trigger via `?triggerId=<id>`.
+
+```json
+{
+  "success": true,
+  "data": {
+    "total": 5,
+    "succeeded": 4,
+    "failed": 1,
+    "failures": [{ "id": "...", "error": "Connection refused" }]
+  }
+}
+```
+
+### POST `/api/dlq/purge`
+
+Mark entries as `purged` (soft delete). Supports filtering by status, triggerId, and age.
+
+**Request body:**
+
+```json
+{
+  "status": "pending",
+  "triggerId": "507f1f77bcf86cd799439011",
+  "olderThanMs": 604800000
+}
+```
+
+`olderThanMs` example: `604800000` = 7 days.
+
+## Integration
+
+Failures are automatically recorded by the event poller (`src/worker/poller.js`) whenever a trigger action throws after all retries. No manual instrumentation is required.
+
+## Example: Retry All Failed Webhooks
+
+```bash
+# 1. Check how many are pending
+curl http://localhost:5000/api/dlq/stats
+
+# 2. Re-drive all pending entries
+curl -X POST http://localhost:5000/api/dlq/redrive-all
+
+# 3. Purge entries older than 7 days
+curl -X POST http://localhost:5000/api/dlq/purge \
+  -H "Content-Type: application/json" \
+  -d '{"olderThanMs": 604800000}'
+```


### PR DESCRIPTION
## Summary

Implements #261 — Backend: DLQ Management UI and Re-drive API Endpoint.

Closes #261

## Changes

- **`FailedAction` model** — dedicated `failed_actions` MongoDB collection with a `pending → redriving → resolved / purged` status lifecycle
- **`dlq.service`** — `recordFailure`, `listFailures`, `redriveOne`, `redriveAll`, `purge`, `getStats`
- **`dlq.controller` + `dlq.routes`** — 5 REST endpoints with full Swagger/OpenAPI annotations
- **`poller.js`** — automatically records failures into the DLQ after all retries are exhausted
- **`app.js`** — registers `/api/dlq` routes
- **`docs/dlq.md`** — full documentation with API reference and usage examples

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/dlq/stats` | Counts per status |
| GET | `/api/dlq/entries` | Paginated list with filters |
| POST | `/api/dlq/entries/:id/redrive` | Re-drive a single entry |
| POST | `/api/dlq/redrive-all` | Retry all pending entries |
| POST | `/api/dlq/purge` | Soft-delete by status/triggerId/age |

## Tests

7 unit tests added in `backend/test/dlq.test.js` — all passing.