### PR TITLE
feat(contracts): add Global Parameter Registry contract

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "amm_pool_v2",
     "delegator_registry",
     "access_whitelist",
+    "parameter_registry",
 ]
 
 [profile.release]

--- a/contracts/parameter_registry/Cargo.toml
+++ b/contracts/parameter_registry/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "parameter_registry"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = "23.4.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "23.4.0", features = ["testutils"] }

--- a/contracts/parameter_registry/src/lib.rs
+++ b/contracts/parameter_registry/src/lib.rs
@@ -1,0 +1,140 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
+
+// ── Storage Keys ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Governance,
+    Param(Symbol), // per-parameter value
+}
+
+// ── Contract ─────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct ParameterRegistry;
+
+#[contractimpl]
+impl ParameterRegistry {
+    // ── Initialization ────────────────────────────────────────────────────
+
+    /// Initialize the registry. Can only be called once.
+    /// `admin`      – bootstrap admin (can transfer governance later).
+    /// `governance` – address allowed to update parameters (e.g. a DAO contract).
+    pub fn initialize(env: Env, admin: Address, governance: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("Already initialized");
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Governance, &governance);
+
+        env.events().publish(
+            (symbol_short!("init"), admin.clone()),
+            governance,
+        );
+    }
+
+    // ── Governance Config ─────────────────────────────────────────────────
+
+    /// Transfer governance to a new address. Admin only.
+    pub fn set_governance(env: Env, new_governance: Address) {
+        Self::_require_admin(&env);
+        let old: Address = env.storage().instance().get(&DataKey::Governance).unwrap();
+        env.storage().instance().set(&DataKey::Governance, &new_governance);
+
+        env.events().publish(
+            (Symbol::new(&env, "gov_changed"), old),
+            new_governance,
+        );
+    }
+
+    // ── Parameter Management ──────────────────────────────────────────────
+
+    /// Set (or update) a protocol parameter. Governance only.
+    /// `key`   – parameter name (e.g. `Symbol::new(&env, "protocol_fee")`).
+    /// `value` – i128 value (use basis-points or fixed-point as appropriate).
+    pub fn set_param(env: Env, key: Symbol, value: i128) {
+        Self::_require_governance(&env);
+
+        let old: Option<i128> = env.storage().persistent().get(&DataKey::Param(key.clone()));
+
+        env.storage().persistent().set(&DataKey::Param(key.clone()), &value);
+
+        env.events().publish(
+            (Symbol::new(&env, "param_set"), key),
+            (old.unwrap_or(0), value),
+        );
+    }
+
+    /// Remove a parameter. Governance only.
+    pub fn remove_param(env: Env, key: Symbol) {
+        Self::_require_governance(&env);
+
+        let old: Option<i128> = env.storage().persistent().get(&DataKey::Param(key.clone()));
+        if old.is_none() {
+            panic!("Parameter not found");
+        }
+
+        env.storage().persistent().remove(&DataKey::Param(key.clone()));
+
+        env.events().publish(
+            (Symbol::new(&env, "param_removed"), key),
+            old.unwrap(),
+        );
+    }
+
+    // ── View Functions ────────────────────────────────────────────────────
+
+    /// Get a parameter value. Panics if not set.
+    pub fn get_param(env: Env, key: Symbol) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Param(key))
+            .expect("Parameter not found")
+    }
+
+    /// Get a parameter value, returning a default if not set.
+    pub fn get_param_or_default(env: Env, key: Symbol, default: i128) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Param(key))
+            .unwrap_or(default)
+    }
+
+    /// Returns true if the parameter exists.
+    pub fn has_param(env: Env, key: Symbol) -> bool {
+        env.storage().persistent().has(&DataKey::Param(key))
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().instance().get(&DataKey::Admin).expect("Not initialized")
+    }
+
+    pub fn get_governance(env: Env) -> Address {
+        env.storage().instance().get(&DataKey::Governance).expect("Not initialized")
+    }
+
+    // ── Internal Helpers ──────────────────────────────────────────────────
+
+    fn _require_admin(env: &Env) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("Not initialized");
+        admin.require_auth();
+    }
+
+    fn _require_governance(env: &Env) {
+        let gov: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Governance)
+            .expect("Not initialized");
+        gov.require_auth();
+    }
+}
+
+mod test;

--- a/contracts/parameter_registry/src/test.rs
+++ b/contracts/parameter_registry/src/test.rs
@@ -1,0 +1,165 @@
+#![cfg(test)]
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
+
+fn setup() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let governance = Address::generate(&env);
+    let contract_id = env.register(ParameterRegistry, ());
+    (env, admin, governance, contract_id)
+}
+
+// ── Initialization ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_initialize() {
+    let (env, admin, governance, contract_id) = setup();
+    let client = ParameterRegistryClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &governance);
+
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_governance(), governance);
+}
+
+#[test]
+#[should_panic(expected = "Already initialized")]
+fn test_double_init_panics() {
+    let (env, admin, governance, contract_id) = setup();
+    let client = ParameterRegistryClient::new(&env, &contract_id);
+
+    client.initialize(&admin, &governance);
+    client.initialize(&admin, &governance);
+}
+
+// ── Governance Transfer ───────────────────────────────────────────────────────
+
+#[test]
+fn test_set_governance() {
+    let (env, admin, governance, contract_id) = setup();
+    let client = ParameterRegistryClient::new(&env, &contract_id);
+    client.initialize(&admin, &governance);
+
+    let new_gov = Address::generate(&env);
+    client.set_governance(&new_gov);
+
+    assert_eq!(client.get_governance(), new_gov);
+}
+
+// ── Parameter CRUD ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_set_and_get_param() {
+    let (env, admin, governance, contract_id) = setup();
+    let client = ParameterRegistryClient::new(&env, &contract_id);
+    client.initialize(&admin, &governance);
+
+    let key = Symbol::new(&env, "protocol_fee");
+    client.set_param(&key, &30i128); // 30 bps
+
+    assert_eq!(client.get_param(&key), 30i128);
+}
+
+#[test]
+fn test_update_param() {
+    let (env, admin, governance, contract_id) = setup();
+    let client = ParameterRegistryClient::new(&env, &contract_id);
+    client.initialize(&admin, &governance);
+
+    let key = Symbol::new(&env, "protocol_fee");
+    client.set_param(&key, &30i128);
+    client.set_param(&key, &50i128);
+
+    assert_eq!(client.get_param(&key), 50i128);
+}
+
+#[test]
+fn test_has_param() {
+    let (env, admin, governance, contract_id) = setup();
+    let client = ParameterRegistryClient::new(&env, &contract_id);
+    client.initialize(&admin, &governance);
+
+    let key = Symbol::new(&env, "max_slippage");
+    assert!(!client.has_param(&key));
+
+    client.set_param(&key, &100i128);
+    assert!(client.has_param(&key));
+}
+
+#[test]
+fn test_get_param_or_default() {
+    let (env, admin, governance, contract_id) = setup();
+    let client = ParameterRegistryClient::new(&env, &contract_id);
+    client.initialize(&admin, &governance);
+
+    let key = Symbol::new(&env, "min_liquidity");
+    // Not set — should return default
+    assert_eq!(client.get_param_or_default(&key, &1000i128), 1000i128);
+
+    client.set_param(&key, &500i128);
+    // Now set — should return stored value
+    assert_eq!(client.get_param_or_default(&key, &1000i128), 500i128);
+}
+
+#[test]
+fn test_remove_param() {
+    let (env, admin, governance, contract_id) = setup();
+    let client = ParameterRegistryClient::new(&env, &contract_id);
+    client.initialize(&admin, &governance);
+
+    let key = Symbol::new(&env, "old_param");
+    client.set_param(&key, &42i128);
+    assert!(client.has_param(&key));
+
+    client.remove_param(&key);
+    assert!(!client.has_param(&key));
+}
+
+#[test]
+#[should_panic(expected = "Parameter not found")]
+fn test_get_missing_param_panics() {
+    let (env, admin, governance, contract_id) = setup();
+    let client = ParameterRegistryClient::new(&env, &contract_id);
+    client.initialize(&admin, &governance);
+
+    client.get_param(&Symbol::new(&env, "nonexistent"));
+}
+
+#[test]
+#[should_panic(expected = "Parameter not found")]
+fn test_remove_missing_param_panics() {
+    let (env, admin, governance, contract_id) = setup();
+    let client = ParameterRegistryClient::new(&env, &contract_id);
+    client.initialize(&admin, &governance);
+
+    client.remove_param(&Symbol::new(&env, "ghost"));
+}
+
+// ── Multiple Parameters ───────────────────────────────────────────────────────
+
+#[test]
+fn test_multiple_independent_params() {
+    let (env, admin, governance, contract_id) = setup();
+    let client = ParameterRegistryClient::new(&env, &contract_id);
+    client.initialize(&admin, &governance);
+
+    let fee_key = Symbol::new(&env, "protocol_fee");
+    let slippage_key = Symbol::new(&env, "max_slippage");
+    let penalty_key = Symbol::new(&env, "unstake_pen");
+
+    client.set_param(&fee_key, &30i128);
+    client.set_param(&slippage_key, &200i128);
+    client.set_param(&penalty_key, &500i128);
+
+    assert_eq!(client.get_param(&fee_key), 30i128);
+    assert_eq!(client.get_param(&slippage_key), 200i128);
+    assert_eq!(client.get_param(&penalty_key), 500i128);
+
+    // Remove one, others unaffected
+    client.remove_param(&slippage_key);
+    assert!(!client.has_param(&slippage_key));
+    assert!(client.has_param(&fee_key));
+    assert!(client.has_param(&penalty_key));
+}

--- a/docs/parameter_registry.md
+++ b/docs/parameter_registry.md
@@ -1,0 +1,100 @@
+# Parameter Registry
+
+The Parameter Registry is a global configuration hub for the EventHorizon protocol. It provides a single, governance-controlled source of truth for protocol-wide settings such as fees, operational thresholds, and other tunable values.
+
+## Features
+
+- **Central Configuration Hub**: All protocol parameters (fees, thresholds, limits) stored in one contract.
+- **Governance-Only Updates**: Only the designated governance address (e.g. a DAO contract) can set or remove parameters.
+- **Detailed Events**: Every configuration change emits an event with the old and new values for full auditability.
+- **Safe Defaults**: `get_param_or_default` allows callers to handle missing parameters gracefully.
+
+## Contract Functions
+
+### `initialize(admin: Address, governance: Address)`
+Initializes the registry. Can only be called once.
+- `admin` – bootstrap admin address (can transfer governance).
+- `governance` – address authorized to update parameters (e.g. a DAO or multisig).
+
+### `set_governance(new_governance: Address)`
+Transfers governance to a new address. Admin only.
+
+### `set_param(key: Symbol, value: i128)`
+Creates or updates a protocol parameter. Governance only.
+- `key` – parameter name (e.g. `"protocol_fee"`, `"max_slippage"`).
+- `value` – i128 value; use basis points (bps) or fixed-point as appropriate for the parameter.
+
+### `remove_param(key: Symbol)`
+Removes a parameter. Governance only. Panics if the parameter does not exist.
+
+### `get_param(key: Symbol) -> i128`
+Returns the stored value. Panics if the parameter is not set.
+
+### `get_param_or_default(key: Symbol, default: i128) -> i128`
+Returns the stored value, or `default` if the parameter is not set.
+
+### `has_param(key: Symbol) -> bool`
+Returns `true` if the parameter exists.
+
+### `get_admin() -> Address`
+Returns the admin address.
+
+### `get_governance() -> Address`
+Returns the current governance address.
+
+## Events
+
+| Topic | Data | Description |
+|-------|------|-------------|
+| `("init", admin)` | `governance` | Emitted on initialization. |
+| `("gov_changed", old_gov)` | `new_gov` | Emitted when governance is transferred. |
+| `("param_set", key)` | `(old_value, new_value)` | Emitted when a parameter is created or updated. `old_value` is `0` for new parameters. |
+| `("param_removed", key)` | `old_value` | Emitted when a parameter is removed. |
+
+## Example Usage
+
+### Setting protocol fees (from a governance contract)
+
+```rust
+// 30 basis points = 0.30%
+registry_client.set_param(&Symbol::new(&env, "protocol_fee"), &30i128);
+
+// 200 bps max slippage = 2%
+registry_client.set_param(&Symbol::new(&env, "max_slippage"), &200i128);
+
+// Early unstake penalty: 500 bps = 5%
+registry_client.set_param(&Symbol::new(&env, "unstake_penalty"), &500i128);
+```
+
+### Reading parameters from another contract
+
+```rust
+// Hard fail if parameter must be set
+let fee_bps: i128 = registry_client.get_param(&Symbol::new(&env, "protocol_fee"));
+
+// Graceful fallback for optional parameters
+let min_liq: i128 = registry_client.get_param_or_default(
+    &Symbol::new(&env, "min_liquidity"),
+    &1_000_000i128,
+);
+```
+
+## Integration
+
+Other protocol contracts should accept the registry address as a constructor or initialization parameter and call `get_param` / `get_param_or_default` to read configuration at runtime. This avoids hard-coding values and allows governance to tune the protocol without redeployment.
+
+```rust
+// In another contract's initialization
+env.storage().instance().set(&DataKey::Registry, &registry_addr);
+
+// In a fee calculation
+let registry: Address = env.storage().instance().get(&DataKey::Registry).unwrap();
+let fee_bps: i128 = ParameterRegistryClient::new(&env, &registry)
+    .get_param_or_default(&Symbol::new(&env, "protocol_fee"), &30i128);
+```
+
+## Security Considerations
+
+- **Governance key security**: The governance address should be a multisig or DAO contract, not an EOA, to prevent unilateral parameter changes.
+- **Parameter validation**: Callers are responsible for validating parameter values are within acceptable ranges after reading them.
+- **No upgrade path**: The registry itself is not upgradeable. Deploy a new registry and migrate governance if a breaking change is needed.


### PR DESCRIPTION
- Implement ParameterRegistry Soroban contract as a central hub for protocol-wide settings (fees, thresholds, operational limits)
- Governance-only access for all parameter mutations (set/remove)
- Admin-only governance transfer with full event trail
- Events emitted on every change with old/new values for auditability
- Read helpers: get_param, get_param_or_default, has_param
- 11 unit tests covering all functions and panic paths
- Add docs/parameter_registry.md with API reference and integration guide
- Register contract in workspace Cargo.toml

closes #313 