### PR TITLE
feat(backend): add webhook IP whitelist validation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,3 +38,8 @@ REDIS_PASSWORD=
 
 # Worker configuration
 WORKER_CONCURRENCY=5
+
+# Webhook destination IP validation
+# Blocks private/internal/link-local destinations by default. Set to false only for local testing.
+IP_WHITELIST_ENFORCE=true
+IP_WHITELIST_ALLOW_PRIVATE=false

--- a/backend/__tests__/ipWhitelist.controller.test.js
+++ b/backend/__tests__/ipWhitelist.controller.test.js
@@ -1,0 +1,125 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const IpWhitelist = require('../src/models/ipWhitelist.model');
+const ipWhitelistService = require('../src/services/ipWhitelist.service');
+const controller = require('../src/controllers/ipWhitelist.controller');
+
+const originalFind = IpWhitelist.find;
+const originalFindOneAndUpdate = IpWhitelist.findOneAndUpdate;
+const originalFindOneAndDelete = IpWhitelist.findOneAndDelete;
+const originalCreateEntry = ipWhitelistService.createEntry;
+const originalNormalizeCidr = ipWhitelistService.normalizeCidr;
+
+function responseRecorder() {
+    return {
+        statusCode: 200,
+        payload: undefined,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.payload = payload;
+            return this;
+        },
+        send() {
+            this.sent = true;
+            return this;
+        },
+    };
+}
+
+function request(body = {}, params = {}) {
+    return {
+        body,
+        params,
+        user: {
+            id: 'user-1',
+            organization: { _id: 'org-1' },
+        },
+    };
+}
+
+test.afterEach(() => {
+    IpWhitelist.find = originalFind;
+    IpWhitelist.findOneAndUpdate = originalFindOneAndUpdate;
+    IpWhitelist.findOneAndDelete = originalFindOneAndDelete;
+    ipWhitelistService.createEntry = originalCreateEntry;
+    ipWhitelistService.normalizeCidr = originalNormalizeCidr;
+});
+
+test('listEntries scopes results to the current organization', async () => {
+    let query;
+    IpWhitelist.find = (receivedQuery) => {
+        query = receivedQuery;
+        return {
+            sort: async () => [{ cidr: '203.0.113.0/24' }],
+        };
+    };
+
+    const res = responseRecorder();
+    await controller.listEntries(request(), res, () => {});
+
+    assert.deepEqual(query, { organization: 'org-1' });
+    assert.equal(res.payload.success, true);
+    assert.equal(res.payload.data[0].cidr, '203.0.113.0/24');
+});
+
+test('createEntry uses the current organization and user', async () => {
+    let input;
+    ipWhitelistService.createEntry = async (receivedInput) => {
+        input = receivedInput;
+        return { _id: 'entry-1', cidr: '203.0.113.0/24' };
+    };
+
+    const res = responseRecorder();
+    await controller.createEntry(request({
+        cidr: '203.0.113.0/24',
+        label: 'partner',
+        enabled: true,
+    }), res, () => {});
+
+    assert.deepEqual(input, {
+        organizationId: 'org-1',
+        cidr: '203.0.113.0/24',
+        label: 'partner',
+        enabled: true,
+        addedBy: 'user-1',
+    });
+    assert.equal(res.statusCode, 201);
+});
+
+test('updateEntry scopes updates and normalizes CIDR', async () => {
+    let query;
+    let updates;
+    ipWhitelistService.normalizeCidr = () => '203.0.113.0/24';
+    IpWhitelist.findOneAndUpdate = async (receivedQuery, receivedUpdates) => {
+        query = receivedQuery;
+        updates = receivedUpdates;
+        return { _id: 'entry-1', ...updates };
+    };
+
+    const res = responseRecorder();
+    await controller.updateEntry(request({
+        cidr: '203.0.113.1',
+        enabled: false,
+    }, { id: 'entry-1' }), res, () => {});
+
+    assert.deepEqual(query, { _id: 'entry-1', organization: 'org-1' });
+    assert.deepEqual(updates, { cidr: '203.0.113.0/24', enabled: false });
+    assert.equal(res.payload.success, true);
+});
+
+test('deleteEntry scopes deletion to the current organization', async () => {
+    let query;
+    IpWhitelist.findOneAndDelete = async (receivedQuery) => {
+        query = receivedQuery;
+        return { _id: 'entry-1' };
+    };
+
+    const res = responseRecorder();
+    await controller.deleteEntry(request({}, { id: 'entry-1' }), res, () => {});
+
+    assert.deepEqual(query, { _id: 'entry-1', organization: 'org-1' });
+    assert.equal(res.statusCode, 204);
+});

--- a/backend/__tests__/ipWhitelist.service.test.js
+++ b/backend/__tests__/ipWhitelist.service.test.js
@@ -1,0 +1,118 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const dns = require('dns').promises;
+const IpWhitelist = require('../src/models/ipWhitelist.model');
+const ipWhitelistService = require('../src/services/ipWhitelist.service');
+
+const originalLookup = dns.lookup;
+const originalFind = IpWhitelist.find;
+
+function mockEntries(entries) {
+    IpWhitelist.find = () => ({
+        lean: async () => entries,
+    });
+}
+
+test.afterEach(() => {
+    dns.lookup = originalLookup;
+    IpWhitelist.find = originalFind;
+});
+
+test('normalizes exact IPs and CIDR ranges', () => {
+    assert.equal(ipWhitelistService.normalizeCidr('203.0.113.10'), '203.0.113.10/32');
+    assert.equal(ipWhitelistService.normalizeCidr('203.0.113.0/24'), '203.0.113.0/24');
+    assert.equal(ipWhitelistService.normalizeCidr('2001:db8::1'), '2001:db8::1/128');
+});
+
+test('rejects private and metadata destinations even when allowlist is empty', async () => {
+    mockEntries([]);
+
+    await assert.rejects(
+        ipWhitelistService.validateUrl('http://169.254.169.254/latest/meta-data', 'org-1'),
+        (error) => error.code === 'WEBHOOK_DESTINATION_BLOCKED'
+            && /private or internal IP/.test(error.message)
+    );
+});
+
+test('rejects IPv6 loopback literal destinations', async () => {
+    mockEntries([]);
+
+    await assert.rejects(
+        ipWhitelistService.validateUrl('http://[::1]/hook', 'org-1'),
+        (error) => error.code === 'WEBHOOK_DESTINATION_BLOCKED'
+            && /private or internal IP/.test(error.message)
+    );
+});
+
+test('allows public destinations when the organization allowlist is empty', async () => {
+    mockEntries([]);
+    dns.lookup = async () => [{ address: '203.0.113.42', family: 4 }];
+
+    const result = await ipWhitelistService.validateUrl('https://hooks.example.com/path', 'org-1');
+
+    assert.equal(result.pinnedAddress, '203.0.113.42');
+    assert.equal(result.pinnedFamily, 4);
+});
+
+test('rejects public destinations outside a configured organization allowlist', async () => {
+    mockEntries([{ cidr: '198.51.100.0/24' }]);
+    dns.lookup = async () => [{ address: '203.0.113.42', family: 4 }];
+
+    await assert.rejects(
+        ipWhitelistService.validateUrl('https://hooks.example.com/path', 'org-1'),
+        (error) => error.code === 'WEBHOOK_DESTINATION_BLOCKED'
+            && /not in the organization whitelist/.test(error.message)
+    );
+});
+
+test('accepts destinations inside a configured CIDR allowlist', async () => {
+    mockEntries([{ cidr: '203.0.113.0/24' }]);
+    dns.lookup = async () => [{ address: '203.0.113.42', family: 4 }];
+
+    const result = await ipWhitelistService.validateUrl('https://hooks.example.com/path', 'org-1');
+
+    assert.equal(result.pinnedAddress, '203.0.113.42');
+});
+
+test('save-time validation can return a DNS warning without allowing send-time bypass', async () => {
+    mockEntries([]);
+    dns.lookup = async () => {
+        throw new Error('temporary DNS failure');
+    };
+
+    const saveResult = await ipWhitelistService.validateUrl(
+        'https://temporarily-down.example.com/hook',
+        'org-1',
+        { allowDnsFailure: true }
+    );
+    assert.match(saveResult.warnings[0], /DNS resolution failed/);
+
+    await assert.rejects(
+        ipWhitelistService.validateUrl('https://temporarily-down.example.com/hook', 'org-1'),
+        (error) => error.code === 'WEBHOOK_DESTINATION_BLOCKED'
+            && /could not be resolved/.test(error.message)
+    );
+});
+
+test('pinned agent lookup returns the validated IP for the original hostname', async () => {
+    mockEntries([]);
+    dns.lookup = async () => [{ address: '203.0.113.42', family: 4 }];
+
+    const result = await ipWhitelistService.validateUrl('https://hooks.example.com/path', 'org-1');
+
+    await new Promise((resolve, reject) => {
+        result.agents.httpsAgent.options.lookup('hooks.example.com', {}, (error, address, family) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            try {
+                assert.equal(address, '203.0.113.42');
+                assert.equal(family, 4);
+                resolve();
+            } catch (assertionError) {
+                reject(assertionError);
+            }
+        });
+    });
+});

--- a/backend/__tests__/trigger.ipWhitelist.test.js
+++ b/backend/__tests__/trigger.ipWhitelist.test.js
@@ -1,0 +1,133 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Trigger = require('../src/models/trigger.model');
+const triggerController = require('../src/controllers/trigger.controller');
+const ipWhitelistService = require('../src/services/ipWhitelist.service');
+
+const originalSave = Trigger.prototype.save;
+const originalFindOne = Trigger.findOne;
+const originalFindOneAndUpdate = Trigger.findOneAndUpdate;
+const originalValidateUrl = ipWhitelistService.validateUrl;
+
+function req(body = {}, params = {}) {
+    return {
+        body,
+        params,
+        get() {
+            return 'test-agent';
+        },
+        ip: '127.0.0.1',
+        user: {
+            id: 'user-1',
+            organization: { _id: 'org-1' },
+        },
+    };
+}
+
+function res() {
+    return {
+        statusCode: 200,
+        payload: undefined,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.payload = payload;
+            return this;
+        },
+    };
+}
+
+test.afterEach(() => {
+    Trigger.prototype.save = originalSave;
+    Trigger.findOne = originalFindOne;
+    Trigger.findOneAndUpdate = originalFindOneAndUpdate;
+    ipWhitelistService.validateUrl = originalValidateUrl;
+});
+
+test('createTrigger validates webhook destination before saving', async () => {
+    let validateInput;
+    let saved = false;
+
+    ipWhitelistService.validateUrl = async (url, organizationId, options) => {
+        validateInput = { url, organizationId, options };
+        return { warnings: ['DNS resolution failed: temporary'] };
+    };
+    Trigger.prototype.save = async function save() {
+        saved = true;
+        return this;
+    };
+
+    const response = res();
+    await triggerController.createTrigger(req({
+        contractId: 'contract-1',
+        eventName: 'Event',
+        actionType: 'webhook',
+        actionUrl: 'https://hooks.example.com/event',
+    }), response, () => {});
+
+    assert.equal(saved, true);
+    assert.deepEqual(validateInput, {
+        url: 'https://hooks.example.com/event',
+        organizationId: 'org-1',
+        options: { allowDnsFailure: true },
+    });
+    assert.equal(response.statusCode, 201);
+    assert.deepEqual(response.payload.warnings, ['DNS resolution failed: temporary']);
+});
+
+test('createTrigger forwards blocked webhook destinations and does not save', async () => {
+    let saved = false;
+    const blocked = new ipWhitelistService.WebhookDestinationBlockedError('blocked');
+
+    ipWhitelistService.validateUrl = async () => {
+        throw blocked;
+    };
+    Trigger.prototype.save = async function save() {
+        saved = true;
+        return this;
+    };
+
+    let forwardedError;
+    await triggerController.createTrigger(req({
+        contractId: 'contract-1',
+        eventName: 'Event',
+        actionType: 'webhook',
+        actionUrl: 'http://169.254.169.254/latest/meta-data',
+    }), res(), (error) => {
+        forwardedError = error;
+    });
+
+    assert.equal(saved, false);
+    assert.equal(forwardedError, blocked);
+});
+
+test('updateTrigger validates the effective webhook destination', async () => {
+    let validateInput;
+    Trigger.findOne = async () => ({
+        actionType: 'webhook',
+        actionUrl: 'https://old.example.com/hook',
+    });
+    Trigger.findOneAndUpdate = async () => ({
+        _id: 'trigger-1',
+        actionType: 'webhook',
+        actionUrl: 'https://new.example.com/hook',
+    });
+    ipWhitelistService.validateUrl = async (url, organizationId, options) => {
+        validateInput = { url, organizationId, options };
+        return { warnings: [] };
+    };
+
+    const response = res();
+    await triggerController.updateTrigger(req({
+        actionUrl: 'https://new.example.com/hook',
+    }, { id: 'trigger-1' }), response, () => {});
+
+    assert.deepEqual(validateInput, {
+        url: 'https://new.example.com/hook',
+        organizationId: 'org-1',
+        options: { allowDnsFailure: true },
+    });
+    assert.equal(response.payload.data.actionUrl, 'https://new.example.com/hook');
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^8.3.1",
     "ioredis": "^5.3.0",
+    "ipaddr.js": "^1.9.1",
     "joi": "^18.1.1",
     "jsonpath-plus": "^10.4.0",
     "jsonwebtoken": "^9.0.3",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -24,6 +24,7 @@ app.use('/api/auth', authRateLimiter);
 app.use('/api/docs', require('./routes/docs.routes'));
 app.use('/api/triggers', require('./routes/trigger.routes'));
 app.use('/api/invitations', require('./routes/invitation.routes'));
+app.use('/api/admin/ip-whitelist', require('./routes/ipWhitelist.routes'));
 // app.use('/api/team', require('./routes/team.routes'));
 app.use('/api/queue', require('./routes/queue.routes'));
 app.use('/api/discovery', require('./routes/discovery.routes'));

--- a/backend/src/controllers/ipWhitelist.controller.js
+++ b/backend/src/controllers/ipWhitelist.controller.js
@@ -1,0 +1,72 @@
+const IpWhitelist = require('../models/ipWhitelist.model');
+const ipWhitelistService = require('../services/ipWhitelist.service');
+const AppError = require('../utils/appError');
+const asyncHandler = require('../utils/asyncHandler');
+
+exports.listEntries = asyncHandler(async (req, res) => {
+    const entries = await IpWhitelist.find({
+        organization: req.user.organization._id,
+    }).sort({ createdAt: -1 });
+
+    res.json({
+        success: true,
+        data: entries,
+    });
+});
+
+exports.createEntry = asyncHandler(async (req, res) => {
+    const entry = await ipWhitelistService.createEntry({
+        organizationId: req.user.organization._id,
+        cidr: req.body.cidr,
+        label: req.body.label,
+        enabled: req.body.enabled,
+        addedBy: req.user.id,
+    });
+
+    res.status(201).json({
+        success: true,
+        data: entry,
+    });
+});
+
+exports.updateEntry = asyncHandler(async (req, res) => {
+    const updates = {};
+
+    if (req.body.cidr !== undefined) {
+        updates.cidr = ipWhitelistService.normalizeCidr(req.body.cidr);
+    }
+    if (req.body.label !== undefined) {
+        updates.label = req.body.label;
+    }
+    if (req.body.enabled !== undefined) {
+        updates.enabled = req.body.enabled;
+    }
+
+    const entry = await IpWhitelist.findOneAndUpdate(
+        { _id: req.params.id, organization: req.user.organization._id },
+        updates,
+        { new: true, runValidators: true }
+    );
+
+    if (!entry) {
+        throw new AppError('IP whitelist entry not found', 404);
+    }
+
+    res.json({
+        success: true,
+        data: entry,
+    });
+});
+
+exports.deleteEntry = asyncHandler(async (req, res) => {
+    const entry = await IpWhitelist.findOneAndDelete({
+        _id: req.params.id,
+        organization: req.user.organization._id,
+    });
+
+    if (!entry) {
+        throw new AppError('IP whitelist entry not found', 404);
+    }
+
+    res.status(204).send();
+});

--- a/backend/src/controllers/trigger.controller.js
+++ b/backend/src/controllers/trigger.controller.js
@@ -2,6 +2,22 @@ const Trigger = require('../models/trigger.model');
 const logger = require('../config/logger');
 const AppError = require('../utils/appError');
 const asyncHandler = require('../utils/asyncHandler');
+const ipWhitelistService = require('../services/ipWhitelist.service');
+
+async function validateWebhookDestinationIfNeeded(body, organizationId, currentTrigger = null) {
+    const actionType = body.actionType ?? currentTrigger?.actionType ?? 'webhook';
+    const actionUrl = body.actionUrl ?? currentTrigger?.actionUrl;
+
+    if (actionType !== 'webhook' || !actionUrl) {
+        return [];
+    }
+
+    const result = await ipWhitelistService.validateUrl(actionUrl, organizationId, {
+        allowDnsFailure: true,
+    });
+
+    return result.warnings || [];
+}
 
 exports.createTrigger = asyncHandler(async (req, res) => {
     logger.info('Creating new trigger', {
@@ -12,6 +28,11 @@ exports.createTrigger = asyncHandler(async (req, res) => {
         userId: req.user.id,
         organizationId: req.user.organization._id,
     });
+
+    const warnings = await validateWebhookDestinationIfNeeded(
+        req.body,
+        req.user.organization._id
+    );
 
     const trigger = new Trigger({
         ...req.body,
@@ -30,6 +51,7 @@ exports.createTrigger = asyncHandler(async (req, res) => {
     res.status(201).json({
         success: true,
         data: trigger,
+        warnings,
     });
 });
 
@@ -93,13 +115,12 @@ exports.updateTrigger = asyncHandler(async (req, res) => {
         organizationId: req.user.organization._id,
     });
 
-    const trigger = await Trigger.findOneAndUpdate(
-        { _id: req.params.id, organization: req.user.organization._id },
-        req.body,
-        { new: true, runValidators: true }
-    );
+    const existingTrigger = await Trigger.findOne({
+        _id: req.params.id,
+        organization: req.user.organization._id,
+    });
 
-    if (!trigger) {
+    if (!existingTrigger) {
         logger.warn('Trigger not found for update', {
             triggerId: req.params.id,
             ip: req.ip,
@@ -107,6 +128,18 @@ exports.updateTrigger = asyncHandler(async (req, res) => {
 
         throw new AppError('Trigger not found', 404);
     }
+
+    const warnings = await validateWebhookDestinationIfNeeded(
+        req.body,
+        req.user.organization._id,
+        existingTrigger
+    );
+
+    const trigger = await Trigger.findOneAndUpdate(
+        { _id: req.params.id, organization: req.user.organization._id },
+        req.body,
+        { new: true, runValidators: true }
+    );
 
     logger.info('Trigger updated successfully', {
         triggerId: req.params.id,
@@ -119,5 +152,6 @@ exports.updateTrigger = asyncHandler(async (req, res) => {
     res.json({
         success: true,
         data: trigger,
+        warnings,
     });
 });

--- a/backend/src/middleware/error.middleware.js
+++ b/backend/src/middleware/error.middleware.js
@@ -22,6 +22,13 @@ const normalizeError = (error) => {
         return new AppError(`Invalid ${error.path}: ${error.value}`, 400);
     }
 
+    if (error.code === 'WEBHOOK_DESTINATION_BLOCKED') {
+        return new AppError(error.message, error.statusCode, {
+            details: error.details,
+            isOperational: true,
+        });
+    }
+
     return new AppError(
         isDevelopment() && error.message ? error.message : 'Something went wrong',
         500,

--- a/backend/src/middleware/validation.middleware.js
+++ b/backend/src/middleware/validation.middleware.js
@@ -1,4 +1,5 @@
 const Joi = require('joi');
+const ipWhitelistService = require('../services/ipWhitelist.service');
 const {
     validateFilters,
     MAX_FILTERS_PER_TRIGGER,
@@ -25,6 +26,17 @@ const filtersSchema = Joi.array()
     .messages({
         'any.invalid': '{{#message}}',
     });
+
+const cidrSchema = Joi.string().trim().custom((value, helpers) => {
+    try {
+        ipWhitelistService.normalizeCidr(value);
+        return value;
+    } catch (error) {
+        return helpers.error('any.invalid', { message: error.message });
+    }
+}, 'IP or CIDR validation').messages({
+    'any.invalid': '{{#message}}',
+});
 
 const validationSchemas = {
     triggerCreate: Joi.object({
@@ -65,6 +77,16 @@ const validationSchemas = {
             'manage_users', 'manage_organization', 'view_audit_logs'
         )).required(),
     }),
+    ipWhitelistEntry: Joi.object({
+        cidr: cidrSchema.required(),
+        label: Joi.string().trim().allow('').default(''),
+        enabled: Joi.boolean().default(true),
+    }),
+    ipWhitelistEntryUpdate: Joi.object({
+        cidr: cidrSchema,
+        label: Joi.string().trim().allow(''),
+        enabled: Joi.boolean(),
+    }).min(1),
 };
 
 const mapValidationErrors = (details) =>

--- a/backend/src/models/ipWhitelist.model.js
+++ b/backend/src/models/ipWhitelist.model.js
@@ -1,0 +1,35 @@
+const mongoose = require('mongoose');
+
+const ipWhitelistSchema = new mongoose.Schema({
+    organization: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Organization',
+        required: true,
+        index: true,
+    },
+    cidr: {
+        type: String,
+        required: true,
+        trim: true,
+    },
+    label: {
+        type: String,
+        trim: true,
+        default: '',
+    },
+    enabled: {
+        type: Boolean,
+        default: true,
+    },
+    addedBy: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User',
+        required: true,
+    },
+}, {
+    timestamps: true,
+});
+
+ipWhitelistSchema.index({ organization: 1, cidr: 1 }, { unique: true });
+
+module.exports = mongoose.model('IpWhitelist', ipWhitelistSchema);

--- a/backend/src/routes/ipWhitelist.routes.js
+++ b/backend/src/routes/ipWhitelist.routes.js
@@ -1,0 +1,63 @@
+const express = require('express');
+const router = express.Router();
+const ipWhitelistController = require('../controllers/ipWhitelist.controller');
+const authMiddleware = require('../middleware/auth.middleware');
+const permissionMiddleware = require('../middleware/permission.middleware');
+const {
+    validateBody,
+    validationSchemas,
+} = require('../middleware/validation.middleware');
+
+/**
+ * @openapi
+ * /api/admin/ip-whitelist:
+ *   get:
+ *     summary: List webhook destination IP whitelist entries
+ *     tags:
+ *       - Admin
+ *     responses:
+ *       200:
+ *         description: Whitelist entries for the current organization.
+ */
+router.get(
+    '/',
+    authMiddleware,
+    permissionMiddleware('manage_organization'),
+    ipWhitelistController.listEntries
+);
+
+/**
+ * @openapi
+ * /api/admin/ip-whitelist:
+ *   post:
+ *     summary: Add a webhook destination IP or CIDR whitelist entry
+ *     tags:
+ *       - Admin
+ *     responses:
+ *       201:
+ *         description: Whitelist entry created.
+ */
+router.post(
+    '/',
+    authMiddleware,
+    permissionMiddleware('manage_organization'),
+    validateBody(validationSchemas.ipWhitelistEntry),
+    ipWhitelistController.createEntry
+);
+
+router.patch(
+    '/:id',
+    authMiddleware,
+    permissionMiddleware('manage_organization'),
+    validateBody(validationSchemas.ipWhitelistEntryUpdate),
+    ipWhitelistController.updateEntry
+);
+
+router.delete(
+    '/:id',
+    authMiddleware,
+    permissionMiddleware('manage_organization'),
+    ipWhitelistController.deleteEntry
+);
+
+module.exports = router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -17,6 +17,7 @@ app.use('/api/docs', require('./routes/docs.routes'));
 app.use('/api/auth', require('./routes/auth.routes'));
 app.use('/api/triggers', require('./routes/trigger.routes'));
 app.use('/api/admin/audit', require('./routes/audit.routes'));
+app.use('/api/admin/ip-whitelist', require('./routes/ipWhitelist.routes'));
 
 /**
  * @openapi

--- a/backend/src/services/ipWhitelist.service.js
+++ b/backend/src/services/ipWhitelist.service.js
@@ -1,0 +1,224 @@
+const dns = require('dns').promises;
+const http = require('http');
+const https = require('https');
+const ipaddr = require('ipaddr.js');
+const IpWhitelist = require('../models/ipWhitelist.model');
+
+const ENFORCEMENT_DISABLED = process.env.IP_WHITELIST_ENFORCE === 'false';
+const ALLOW_PRIVATE = process.env.IP_WHITELIST_ALLOW_PRIVATE === 'true';
+
+const DENIED_RANGES = [
+    '0.0.0.0/8',
+    '10.0.0.0/8',
+    '100.64.0.0/10',
+    '127.0.0.0/8',
+    '169.254.0.0/16',
+    '172.16.0.0/12',
+    '192.0.0.0/24',
+    '192.168.0.0/16',
+    '198.18.0.0/15',
+    '224.0.0.0/4',
+    '240.0.0.0/4',
+    '::/128',
+    '::1/128',
+    'fc00::/7',
+    'fe80::/10',
+    'ff00::/8',
+].map((range) => ipaddr.parseCIDR(range));
+
+class WebhookDestinationBlockedError extends Error {
+    constructor(message, details = {}) {
+        super(message);
+        this.name = 'WebhookDestinationBlockedError';
+        this.code = 'WEBHOOK_DESTINATION_BLOCKED';
+        this.statusCode = 400;
+        this.details = details;
+    }
+}
+
+function parseAddress(value) {
+    return ipaddr.process(value);
+}
+
+function normalizeHostname(hostname) {
+    const value = String(hostname || '').trim();
+    if (value.startsWith('[') && value.endsWith(']')) {
+        return value.slice(1, -1);
+    }
+    return value;
+}
+
+function parseCidr(value) {
+    const trimmed = String(value || '').trim();
+    if (!trimmed) {
+        throw new Error('CIDR or IP address is required');
+    }
+
+    if (trimmed.includes('/')) {
+        const [address, prefix] = ipaddr.parseCIDR(trimmed);
+        return [ipaddr.process(address.toString()), prefix];
+    }
+
+    const address = parseAddress(trimmed);
+    return [address, address.kind() === 'ipv4' ? 32 : 128];
+}
+
+function normalizeCidr(value) {
+    const [address, prefix] = parseCidr(value);
+    return `${address.toString()}/${prefix}`;
+}
+
+function matchesRange(address, range) {
+    return address.kind() === range[0].kind() && address.match(range);
+}
+
+function isDeniedAddress(address) {
+    return DENIED_RANGES.some((range) => matchesRange(address, range));
+}
+
+function matchesWhitelist(address, entries) {
+    return entries.some((entry) => matchesRange(address, parseCidr(entry.cidr)));
+}
+
+function parseWebhookUrl(url) {
+    let parsed;
+    try {
+        parsed = new URL(url);
+    } catch (_error) {
+        throw new WebhookDestinationBlockedError('Webhook URL is invalid', { url });
+    }
+
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+        throw new WebhookDestinationBlockedError('Webhook URL must use http or https', {
+            url,
+            protocol: parsed.protocol,
+        });
+    }
+
+    if (!parsed.hostname) {
+        throw new WebhookDestinationBlockedError('Webhook URL must include a hostname', { url });
+    }
+
+    return parsed;
+}
+
+async function resolveHostname(hostname) {
+    const normalizedHostname = normalizeHostname(hostname);
+
+    if (ipaddr.isValid(normalizedHostname)) {
+        const address = parseAddress(normalizedHostname);
+        return [{ address: address.toString(), family: address.kind() === 'ipv4' ? 4 : 6 }];
+    }
+
+    return dns.lookup(normalizedHostname, { all: true, verbatim: true });
+}
+
+function createPinnedAgents(hostname, resolvedTarget) {
+    const normalizedHostname = normalizeHostname(hostname);
+    const lookup = (lookupHostname, _options, callback) => {
+        if (lookupHostname === hostname || normalizeHostname(lookupHostname) === normalizedHostname) {
+            callback(null, resolvedTarget.address, resolvedTarget.family);
+            return;
+        }
+
+        dns.lookup(lookupHostname)
+            .then((result) => callback(null, result.address, result.family))
+            .catch(callback);
+    };
+
+    return {
+        httpAgent: new http.Agent({ lookup }),
+        httpsAgent: new https.Agent({ lookup }),
+    };
+}
+
+async function getEnabledEntries(organizationId) {
+    return IpWhitelist.find({
+        organization: organizationId,
+        enabled: true,
+    }).lean();
+}
+
+async function validateResolvedAddresses(url, organizationId, resolvedAddresses) {
+    const entries = organizationId ? await getEnabledEntries(organizationId) : [];
+
+    for (const resolved of resolvedAddresses) {
+        const address = parseAddress(resolved.address);
+
+        if (!ALLOW_PRIVATE && isDeniedAddress(address)) {
+            throw new WebhookDestinationBlockedError('Webhook destination resolves to a blocked private or internal IP', {
+                url,
+                address: address.toString(),
+            });
+        }
+
+        if (entries.length > 0 && !matchesWhitelist(address, entries)) {
+            throw new WebhookDestinationBlockedError('Webhook destination IP is not in the organization whitelist', {
+                url,
+                address: address.toString(),
+            });
+        }
+    }
+}
+
+async function validateUrl(url, organizationId, options = {}) {
+    const parsed = parseWebhookUrl(url);
+
+    if (ENFORCEMENT_DISABLED) {
+        return { url: parsed.toString(), warnings: ['IP whitelist enforcement is disabled'] };
+    }
+
+    let resolvedAddresses;
+    try {
+        resolvedAddresses = await resolveHostname(parsed.hostname);
+    } catch (error) {
+        if (options.allowDnsFailure) {
+            return {
+                url: parsed.toString(),
+                warnings: [`DNS resolution failed: ${error.message}`],
+            };
+        }
+        throw new WebhookDestinationBlockedError('Webhook destination could not be resolved', {
+            url,
+            hostname: parsed.hostname,
+            reason: error.message,
+        });
+    }
+
+    await validateResolvedAddresses(parsed.toString(), organizationId, resolvedAddresses);
+
+    const pinnedTarget = resolvedAddresses[0];
+    return {
+        url: parsed.toString(),
+        hostname: parsed.hostname,
+        resolvedAddresses,
+        pinnedAddress: pinnedTarget.address,
+        pinnedFamily: pinnedTarget.family,
+        agents: createPinnedAgents(parsed.hostname, pinnedTarget),
+        warnings: [],
+    };
+}
+
+async function createEntry({ organizationId, cidr, label, enabled = true, addedBy }) {
+    const normalized = normalizeCidr(cidr);
+    const entry = new IpWhitelist({
+        organization: organizationId,
+        cidr: normalized,
+        label,
+        enabled,
+        addedBy,
+    });
+    await entry.save();
+    return entry;
+}
+
+module.exports = {
+    WebhookDestinationBlockedError,
+    createEntry,
+    getEnabledEntries,
+    isDeniedAddress,
+    matchesWhitelist,
+    normalizeCidr,
+    parseCidr,
+    validateUrl,
+};

--- a/backend/src/services/webhook.service.js
+++ b/backend/src/services/webhook.service.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const crypto = require('crypto');
 const logger = require('../config/logger');
+const ipWhitelistService = require('./ipWhitelist.service');
 
 /**
  * Webhook service for secure outbound webhook delivery with HMAC signing
@@ -28,6 +29,14 @@ class WebhookService {
      * @returns {Promise} - Axios response
      */
     async sendSignedWebhook(url, payload, secret, options = {}) {
+        const {
+            organizationId,
+            organization,
+            headers: optionHeaders,
+            ...axiosOptions
+        } = options;
+        const effectiveOrganizationId = organizationId || organization;
+        const destination = await ipWhitelistService.validateUrl(url, effectiveOrganizationId);
         const timestamp = new Date().toISOString();
 
         // Generate signature
@@ -38,7 +47,7 @@ class WebhookService {
             'Content-Type': 'application/json',
             'X-EventHorizon-Signature': signature,
             'X-EventHorizon-Timestamp': timestamp,
-            ...options.headers
+            ...optionHeaders
         };
 
         logger.info('Sending signed webhook', {
@@ -51,8 +60,10 @@ class WebhookService {
         try {
             const response = await axios.post(url, payload, {
                 headers,
-                timeout: options.timeout || 30000, // 30 second timeout
-                ...options
+                timeout: axiosOptions.timeout || 30000, // 30 second timeout
+                httpAgent: destination.agents?.httpAgent,
+                httpsAgent: destination.agents?.httpsAgent,
+                ...axiosOptions
             });
 
             logger.info('Webhook sent successfully', {

--- a/backend/src/worker/poller.js
+++ b/backend/src/worker/poller.js
@@ -71,11 +71,11 @@ try {
     });
 
     // Fallback: direct execution with full action routing
-    const axios = require('axios');
     const { sendEventNotification } = require('../services/email.service');
     const { sendDiscordNotification } = require('../services/discord.service');
     const slackService = require('../services/slack.service');
     const telegramService = require('../services/telegram.service');
+    const webhookService = require('../services/webhook.service');
 
     enqueueAction = async function executeTriggerActionDirect(trigger, eventPayload) {
         const { actionType, actionUrl, contractId, eventName } = trigger;
@@ -137,11 +137,11 @@ try {
                 if (!actionUrl) {
                     throw new Error('Missing actionUrl for webhook trigger');
                 }
-                return await axios.post(actionUrl, {
+                return await webhookService.sendSignedWebhook(actionUrl, {
                     contractId,
                     eventName,
                     payload: eventPayload,
-                });
+                }, trigger.webhookSecret, { organizationId: trigger.organization });
 
             default:
                 throw new Error(`Unsupported action type: ${actionType}`);

--- a/backend/src/worker/processor.js
+++ b/backend/src/worker/processor.js
@@ -111,7 +111,8 @@ async function executeSingleAction(trigger, eventPayload) {
             return await webhookService.sendSignedWebhook(
                 actionUrl,
                 payload,
-                trigger.webhookSecret
+                trigger.webhookSecret,
+                { organizationId: trigger.organization }
             );
         }
 
@@ -211,7 +212,8 @@ async function executeBatchAction(trigger, eventPayloads) {
                     await webhookService.sendSignedWebhook(
                         actionUrl,
                         payload,
-                        trigger.webhookSecret
+                        trigger.webhookSecret,
+                        { organizationId: trigger.organization }
                     );
                     break;
                 }

--- a/docs/webhook_ip_whitelist.md
+++ b/docs/webhook_ip_whitelist.md
@@ -1,0 +1,102 @@
+# Webhook Destination IP Whitelisting
+
+EventHorizon validates outbound webhook destinations before dispatching user-configured webhook actions. The goal is to prevent slow or malicious destinations from becoming an SSRF path into private networks, local services, cloud metadata endpoints, or organization-restricted integrations.
+
+## Defaults
+
+IP validation is enabled by default.
+
+```env
+IP_WHITELIST_ENFORCE=true
+IP_WHITELIST_ALLOW_PRIVATE=false
+```
+
+With the default settings:
+
+- Private, loopback, link-local, multicast, and reserved internal ranges are always blocked.
+- The cloud metadata address `169.254.169.254` is blocked through the link-local denylist.
+- If an organization has no enabled whitelist entries, public destinations are allowed.
+- If an organization has one or more enabled whitelist entries, the resolved destination IP must match an enabled entry.
+
+`IP_WHITELIST_ALLOW_PRIVATE=true` is intended only for local development environments.
+
+## Admin API
+
+Whitelist entries are scoped to the authenticated user's organization and require `manage_organization`.
+
+### List entries
+
+```http
+GET /api/admin/ip-whitelist
+Authorization: Bearer <token>
+```
+
+### Add an entry
+
+```http
+POST /api/admin/ip-whitelist
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "cidr": "203.0.113.0/24",
+  "label": "Partner webhook provider",
+  "enabled": true
+}
+```
+
+Exact IPs are accepted and normalized to host CIDR form, for example `203.0.113.10` becomes `203.0.113.10/32`.
+
+### Update an entry
+
+```http
+PATCH /api/admin/ip-whitelist/<entry-id>
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "enabled": false
+}
+```
+
+### Delete an entry
+
+```http
+DELETE /api/admin/ip-whitelist/<entry-id>
+Authorization: Bearer <token>
+```
+
+## Validation Points
+
+Webhook destinations are validated twice:
+
+1. Trigger create/update validates the URL and, when DNS is available, the resolved IP. DNS resolution failures are returned as warnings so a temporary resolver issue does not block saving a trigger.
+2. Webhook dispatch validates again and treats DNS failures or blocked destinations as hard failures.
+
+Send-time validation protects against DNS changes after a trigger is saved.
+
+## DNS Rebinding Protection
+
+The webhook service resolves the destination hostname, validates the resolved IP, then uses a per-request HTTP(S) agent that connects to that validated IP for the original hostname. This prevents a second DNS lookup from returning a different private IP between validation and connection.
+
+## Blocked Destination Example
+
+If a webhook points at the cloud metadata endpoint:
+
+```json
+{
+  "success": false,
+  "status": "fail",
+  "message": "Webhook destination resolves to a blocked private or internal IP",
+  "details": {
+    "url": "http://169.254.169.254/latest/meta-data",
+    "address": "169.254.169.254"
+  }
+}
+```
+
+## Operational Notes
+
+- Use CIDR entries for webhook providers that publish stable egress ranges.
+- Keep entries disabled instead of deleting them when temporarily pausing a partner destination.
+- Avoid enabling private destinations in shared or production environments.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "express": "^4.18.2",
         "express-rate-limit": "^8.3.1",
         "ioredis": "^5.3.0",
+        "ipaddr.js": "^1.9.1",
         "joi": "^18.1.1",
         "jsonpath-plus": "^10.4.0",
         "jsonwebtoken": "^9.0.3",


### PR DESCRIPTION
Closes #259

## Summary

Implements backend IP whitelisting and destination validation for user-configured outbound webhook actions.

This adds an organization-scoped whitelist registry, blocks private/internal webhook destinations by default, validates webhook URLs at trigger save time and send time, and documents the admin API for managing allowed destination IPs/CIDR ranges.

## Security Model

SSRF protection has two layers: a hard-coded denylist of private/internal/link-local/reserved ranges (always enforced) and an optional per-org allowlist (enforced only when entries exist). Validation resolves hostnames at request time and pins the validated IP into a custom HTTP agent, so a second DNS lookup between validation and connect cannot redirect the request to a different (private) IP.

## What Changed

### Added

- `backend/src/models/ipWhitelist.model.js`
  - Organization-scoped whitelist entries
  - Supports exact IPs and CIDR ranges
  - Includes `label`, `enabled`, and `addedBy`

- `backend/src/services/ipWhitelist.service.js`
  - Validates webhook destination URLs
  - Resolves hostnames and checks resolved IPs
  - Blocks private/internal/link-local/reserved ranges by default
  - Blocks cloud metadata IPs such as `169.254.169.254`
  - Supports optional org allowlist enforcement when entries exist
  - Uses pinned-IP HTTP(S) agents to reduce DNS rebinding risk

- `backend/src/controllers/ipWhitelist.controller.js`
- `backend/src/routes/ipWhitelist.routes.js`
  - Adds protected admin CRUD API:
    - `GET /api/admin/ip-whitelist`
    - `POST /api/admin/ip-whitelist`
    - `PATCH /api/admin/ip-whitelist/:id`
    - `DELETE /api/admin/ip-whitelist/:id`
  - Protected with `authMiddleware` and `permissionMiddleware('manage_organization')`

- `docs/webhook_ip_whitelist.md`
  - Documents defaults, admin API usage, validation behavior, DNS rebinding mitigation, and operational notes

### Updated

- `webhook.service.js`
  - Validates outbound webhook destination before dispatch
  - Connects through validated/pinned destination IP

- `trigger.controller.js`
  - Validates webhook destination on trigger create/update
  - DNS failures at save time return warnings
  - Blocked destinations fail fast

- `processor.js` and `poller.js`
  - Pass organization context into webhook delivery for org-scoped validation

- `.env.example`
  - Adds:
    - `IP_WHITELIST_ENFORCE=true`
    - `IP_WHITELIST_ALLOW_PRIVATE=false`

## Behavior

- Private/internal/link-local/reserved IP ranges are blocked.
- Public webhook destinations are allowed when an organization has no enabled whitelist entries.
- If an organization has enabled whitelist entries, webhook destinations must resolve to a matching IP/CIDR.
- Send-time validation is always enforced.
- Trigger create/update performs validation for early feedback, but transient DNS failures are returned as warnings.
- Slack, Telegram, and OAuth outbound calls go to fixed third-party domains and are not subject to this whitelist.

## Tests

Added coverage for:

- IP/CIDR normalization
- Private/internal/metadata IP blocking
- IPv6 loopback blocking
- Empty allowlist behavior
- CIDR allowlist matching
- DNS failure handling
- Pinned-IP agent behavior
- Admin controller org scoping
- Trigger create/update validation

## Test Plan

- [x] New tests: `node --test backend/__tests__/ipWhitelist.*.test.js backend/__tests__/trigger.ipWhitelist.test.js` — 15/15 passing
- [x] Full suite: 66/70 passing; the 4 failures pre-date this PR (Mongo/queue/audit, unrelated to webhook validation)


## Notes

No frontend UI was added in this PR by scope decision. This PR implements the backend registry, validation enforcement, protected admin API, tests, and documentation.

---

