### PR TITLE
feat: add k6 load testing suite with Grafana observability

### DIFF
--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -1,0 +1,287 @@
+# Load Testing with k6 and Grafana
+
+This document covers the automated load testing suite for the EventHorizon backend, implemented with [k6](https://k6.io/) and visualised with Grafana + InfluxDB.
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Project Structure](#project-structure)
+3. [Quick Start](#quick-start)
+4. [Test Scripts](#test-scripts)
+5. [Performance Budget](#performance-budget)
+6. [Grafana Dashboards](#grafana-dashboards)
+7. [CI / PR Integration](#ci--pr-integration)
+8. [Environment Variables](#environment-variables)
+9. [Interpreting Results](#interpreting-results)
+
+---
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| k6 | ≥ 0.50 | `brew install k6` / [k6.io/docs/get-started/installation](https://k6.io/docs/get-started/installation/) |
+| Docker + Compose | ≥ 24 | [docs.docker.com](https://docs.docker.com/get-docker/) |
+| EventHorizon backend | running | `npm run dev:backend` |
+
+---
+
+## Project Structure
+
+```
+load-tests/
+├── docker-compose.yml              # InfluxDB + Grafana stack
+├── grafana/
+│   ├── dashboards/
+│   │   └── k6-eventhorizon.json    # Pre-built Grafana dashboard
+│   └── provisioning/
+│       ├── datasources/
+│       │   └── influxdb.yml        # Auto-wires InfluxDB datasource
+│       └── dashboards/
+│           └── k6.yml              # Dashboard provider config
+└── k6/
+    ├── config.js                   # Shared BASE_URL, credentials, payloads
+    ├── thresholds.js               # Performance budget (PR gates)
+    ├── smoke-test.js               # CI smoke test (10 VUs, 30 s)
+    ├── stress-test.js              # Full stress test (5 000 VUs)
+    ├── auth-load-test.js           # Auth endpoints only
+    ├── triggers-load-test.js       # Triggers CRUD lifecycle
+    └── queue-load-test.js          # Queue & batch endpoints
+```
+
+---
+
+## Quick Start
+
+### 1. Start the observability stack
+
+```bash
+docker compose -f load-tests/docker-compose.yml up -d
+```
+
+- **InfluxDB** → `http://localhost:8086`
+- **Grafana**  → `http://localhost:3001` (admin / admin)
+
+### 2. Start the backend
+
+```bash
+npm run dev:backend
+```
+
+### 3. Run the smoke test (sanity check)
+
+```bash
+k6 run load-tests/k6/smoke-test.js
+```
+
+### 4. Run the full stress test with live metrics
+
+```bash
+k6 run \
+  --out influxdb=http://localhost:8086/k6 \
+  load-tests/k6/stress-test.js
+```
+
+Open Grafana at `http://localhost:3001` → **k6 / EventHorizon k6 Load Tests** to watch metrics in real time.
+
+---
+
+## Test Scripts
+
+### `smoke-test.js`
+
+| Property | Value |
+|----------|-------|
+| VUs | 10 |
+| Duration | 30 s |
+| Purpose | CI gate – runs on every PR |
+
+Covers: health check, login, trigger create/delete, queue stats.
+
+```bash
+k6 run load-tests/k6/smoke-test.js
+```
+
+---
+
+### `stress-test.js`
+
+| Property | Value |
+|----------|-------|
+| Peak VUs | 5 000 |
+| Duration | ~5 min total |
+| Purpose | Full API stress test |
+
+Covers all endpoints: auth, triggers CRUD, queue, discovery.
+
+```bash
+k6 run --out influxdb=http://localhost:8086/k6 load-tests/k6/stress-test.js
+```
+
+Load profile:
+
+```
+30s  → ramp to 100 VUs   (warm-up)
+1m   → ramp to 1 000 VUs
+2m   → ramp to 5 000 VUs (peak)
+1m   → sustain 5 000 VUs
+30s  → ramp down to 0
+```
+
+---
+
+### `auth-load-test.js`
+
+Focuses on `POST /api/auth/login` and `POST /api/auth/refresh` throughput. Useful for validating rate-limiter behaviour.
+
+```bash
+k6 run load-tests/k6/auth-load-test.js
+```
+
+---
+
+### `triggers-load-test.js`
+
+Exercises the full trigger lifecycle: **create → list → update → versions → restore → delete**.
+
+```bash
+k6 run load-tests/k6/triggers-load-test.js
+```
+
+---
+
+### `queue-load-test.js`
+
+Exercises queue and batch endpoints. Accepts HTTP 503 as a valid response when Redis is not configured.
+
+```bash
+k6 run load-tests/k6/queue-load-test.js
+```
+
+---
+
+## Performance Budget
+
+The performance budget is defined in `load-tests/k6/thresholds.js` and is the single source of truth for PR gates.
+
+| Metric | Budget | Notes |
+|--------|--------|-------|
+| `http_req_duration` p(95) | < 500 ms | 95th percentile response time |
+| `http_req_duration` p(99) | < 1 000 ms | Tail latency cap |
+| `http_req_duration` avg | < 200 ms | Average response time |
+| `http_req_failed` | < 1 % | HTTP error rate |
+| `auth_duration` p(95) | < 300 ms | Login / refresh latency |
+| `trigger_duration` p(95) | < 500 ms | Trigger CRUD latency |
+| `queue_duration` p(95) | < 400 ms | Queue read latency |
+| `error_rate` | < 1 % | Custom error counter |
+
+A PR that causes **any** threshold to be breached must not be merged until the regression is fixed.
+
+### Test profiles
+
+| Profile | Export | Use case |
+|---------|--------|----------|
+| `SMOKE_OPTIONS` | `thresholds.js` | CI on every PR |
+| `SOAK_OPTIONS` | `thresholds.js` | Nightly – detect memory leaks |
+| `SPIKE_OPTIONS` | `thresholds.js` | Validate burst resilience |
+
+Import a profile in your script:
+
+```js
+import { SMOKE_OPTIONS } from './thresholds.js';
+export const options = SMOKE_OPTIONS;
+```
+
+---
+
+## Grafana Dashboards
+
+The dashboard is auto-provisioned when the Docker stack starts. It includes:
+
+| Panel | Description |
+|-------|-------------|
+| HTTP Request Rate | Requests per second over time |
+| HTTP Request Duration | p95, p99, avg latency |
+| Active Virtual Users | VU ramp profile |
+| HTTP Error Rate | % of failed requests |
+| Auth Duration p95 | Auth endpoint latency stat |
+| Trigger Duration p95 | Trigger CRUD latency stat |
+| Queue Duration p95 | Queue endpoint latency stat |
+| Triggers Created | Total triggers created counter |
+
+Navigate to `http://localhost:3001` → **Dashboards** → **k6** → **EventHorizon k6 Load Tests**.
+
+---
+
+## CI / PR Integration
+
+Add the following step to your GitHub Actions workflow (`.github/workflows/ci.yml`):
+
+```yaml
+- name: Install k6
+  run: |
+    sudo gpg -k
+    sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg \
+      --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+    echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
+      | sudo tee /etc/apt/sources.list.d/k6.list
+    sudo apt-get update && sudo apt-get install k6
+
+- name: Run smoke test
+  env:
+    BASE_URL: http://localhost:3000
+  run: k6 run load-tests/k6/smoke-test.js
+```
+
+k6 exits with a non-zero code when any threshold is breached, which will fail the CI job automatically.
+
+---
+
+## Environment Variables
+
+All scripts read configuration from environment variables passed via `-e`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BASE_URL` | `http://localhost:3000` | Backend base URL |
+| `TEST_EMAIL` | `loadtest@eventhorizon.dev` | Test user email |
+| `TEST_PASSWORD` | `LoadTest@123` | Test user password |
+| `ADMIN_TOKEN` | `test-admin-token` | Admin API token |
+
+Example:
+
+```bash
+k6 run \
+  -e BASE_URL=https://staging.eventhorizon.dev \
+  -e TEST_EMAIL=ci@eventhorizon.dev \
+  -e TEST_PASSWORD=SecurePass123 \
+  load-tests/k6/stress-test.js
+```
+
+---
+
+## Interpreting Results
+
+k6 prints a summary at the end of each run. Key fields to check:
+
+```
+✓ http_req_duration............: avg=45ms  p(95)=120ms  p(99)=310ms
+✓ http_req_failed..............: 0.12%
+✓ error_rate...................: 0.12%
+✓ trigger_duration.............: avg=80ms  p(95)=210ms
+```
+
+- A `✓` means the threshold passed; `✗` means it was breached.
+- If any `✗` appears, investigate the failing endpoint before merging.
+- Use the Grafana dashboard to correlate latency spikes with VU ramp stages.
+
+---
+
+## See Also
+
+- [k6 documentation](https://k6.io/docs/)
+- [BullMQ / Queue setup](../backend/QUEUE_SETUP.md)
+- [Redis optional fallback](../backend/REDIS_OPTIONAL.md)
+- [Service mesh](service-mesh.md)

--- a/load-tests/docker-compose.yml
+++ b/load-tests/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '3.8'
+
+# EventHorizon Load Testing Observability Stack
+#
+# Starts InfluxDB (k6 metrics sink) and Grafana (dashboards).
+#
+# Usage:
+#   docker compose -f load-tests/docker-compose.yml up -d
+#
+# Then run k6 with InfluxDB output:
+#   k6 run --out influxdb=http://localhost:8086/k6 load-tests/k6/stress-test.js
+#
+# Open Grafana at http://localhost:3001  (admin / admin)
+
+services:
+  influxdb:
+    image: influxdb:1.8
+    container_name: eventhorizon_influxdb
+    ports:
+      - "8086:8086"
+    environment:
+      INFLUXDB_DB: k6
+      INFLUXDB_HTTP_AUTH_ENABLED: "false"
+    volumes:
+      - influxdb_data:/var/lib/influxdb
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8086/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    container_name: eventhorizon_grafana
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+    depends_on:
+      influxdb:
+        condition: service_healthy
+
+volumes:
+  influxdb_data:
+  grafana_data:

--- a/load-tests/grafana/dashboards/k6-eventhorizon.json
+++ b/load-tests/grafana/dashboards/k6-eventhorizon.json
@@ -1,0 +1,135 @@
+{
+  "title": "EventHorizon k6 Load Tests",
+  "uid": "eventhorizon-k6",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "5s",
+  "time": { "from": "now-30m", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "HTTP Request Rate (req/s)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "InfluxDB",
+          "query": "SELECT non_negative_derivative(mean(\"value\"), 1s) FROM \"http_reqs\" WHERE $timeFilter GROUP BY time($__interval) fill(0)",
+          "alias": "req/s"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "HTTP Request Duration (ms)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "InfluxDB",
+          "query": "SELECT percentile(\"value\", 95) FROM \"http_req_duration\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+          "alias": "p95"
+        },
+        {
+          "datasource": "InfluxDB",
+          "query": "SELECT percentile(\"value\", 99) FROM \"http_req_duration\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+          "alias": "p99"
+        },
+        {
+          "datasource": "InfluxDB",
+          "query": "SELECT mean(\"value\") FROM \"http_req_duration\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+          "alias": "avg"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Active Virtual Users",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "InfluxDB",
+          "query": "SELECT last(\"value\") FROM \"vus\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+          "alias": "VUs"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "HTTP Error Rate (%)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "datasource": "InfluxDB",
+          "query": "SELECT mean(\"value\") * 100 FROM \"http_req_failed\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+          "alias": "error %"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red",   "value": 1 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Auth Duration p95 (ms)",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 16, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "InfluxDB",
+          "query": "SELECT percentile(\"value\", 95) FROM \"auth_duration\" WHERE $timeFilter",
+          "alias": "auth p95"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Trigger Duration p95 (ms)",
+      "type": "stat",
+      "gridPos": { "x": 6, "y": 16, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "InfluxDB",
+          "query": "SELECT percentile(\"value\", 95) FROM \"trigger_duration\" WHERE $timeFilter",
+          "alias": "trigger p95"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Queue Duration p95 (ms)",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 16, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "InfluxDB",
+          "query": "SELECT percentile(\"value\", 95) FROM \"queue_duration\" WHERE $timeFilter",
+          "alias": "queue p95"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Triggers Created (total)",
+      "type": "stat",
+      "gridPos": { "x": 18, "y": 16, "w": 6, "h": 4 },
+      "targets": [
+        {
+          "datasource": "InfluxDB",
+          "query": "SELECT last(\"value\") FROM \"triggers_created\" WHERE $timeFilter",
+          "alias": "created"
+        }
+      ]
+    }
+  ]
+}

--- a/load-tests/grafana/provisioning/dashboards/k6.yml
+++ b/load-tests/grafana/provisioning/dashboards/k6.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: k6
+    orgId: 1
+    folder: k6
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/load-tests/grafana/provisioning/datasources/influxdb.yml
+++ b/load-tests/grafana/provisioning/datasources/influxdb.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    database: k6
+    isDefault: true
+    editable: true

--- a/load-tests/k6/auth-load-test.js
+++ b/load-tests/k6/auth-load-test.js
@@ -1,0 +1,91 @@
+/**
+ * Auth endpoint load test
+ *
+ * Focuses on login / register / token-refresh throughput.
+ * Useful for validating rate-limiter behaviour under load.
+ *
+ * Run:
+ *   k6 run load-tests/k6/auth-load-test.js
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+import { BASE_URL, TEST_USER } from './config.js';
+
+const loginDuration   = new Trend('login_duration',   true);
+const refreshDuration = new Trend('refresh_duration', true);
+const errorRate       = new Rate('error_rate');
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 200  },
+    { duration: '1m',  target: 1000 },
+    { duration: '1m',  target: 1000 },
+    { duration: '30s', target: 0    },
+  ],
+  thresholds: {
+    login_duration:   ['p(95)<300'],
+    refresh_duration: ['p(95)<200'],
+    error_rate:       ['rate<0.02'],
+    http_req_failed:  ['rate<0.02'],
+  },
+};
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+export function setup() {
+  // Pre-create the shared test user
+  http.post(
+    `${BASE_URL}/api/auth/register`,
+    JSON.stringify(TEST_USER),
+    { headers: JSON_HEADERS },
+  );
+}
+
+export default function () {
+  // Each VU uses a unique email to avoid lock-out from rate limiting
+  const email = `loadtest+${__VU}@eventhorizon.dev`;
+  const password = TEST_USER.password;
+
+  // Register (idempotent)
+  http.post(
+    `${BASE_URL}/api/auth/register`,
+    JSON.stringify({ ...TEST_USER, email }),
+    { headers: JSON_HEADERS },
+  );
+
+  // Login
+  const loginRes = http.post(
+    `${BASE_URL}/api/auth/login`,
+    JSON.stringify({ email, password }),
+    { headers: JSON_HEADERS },
+  );
+  loginDuration.add(loginRes.timings.duration);
+
+  const loginOk = check(loginRes, {
+    'login 200':    (r) => r.status === 200,
+    'has token':    (r) => { try { return !!JSON.parse(r.body).token; } catch { return false; } },
+    'has refresh':  (r) => { try { return !!JSON.parse(r.body).refreshToken; } catch { return false; } },
+  });
+  errorRate.add(!loginOk);
+
+  let refreshToken;
+  try { refreshToken = JSON.parse(loginRes.body).refreshToken; } catch { /* noop */ }
+
+  // Token refresh
+  if (refreshToken) {
+    const refreshRes = http.post(
+      `${BASE_URL}/api/auth/refresh`,
+      JSON.stringify({ refreshToken }),
+      { headers: JSON_HEADERS },
+    );
+    refreshDuration.add(refreshRes.timings.duration);
+    const refreshOk = check(refreshRes, {
+      'refresh 200': (r) => r.status === 200,
+    });
+    errorRate.add(!refreshOk);
+  }
+
+  sleep(1);
+}

--- a/load-tests/k6/config.js
+++ b/load-tests/k6/config.js
@@ -1,0 +1,25 @@
+/**
+ * Shared configuration for all k6 load test scripts.
+ * Override BASE_URL and credentials via environment variables:
+ *   k6 run -e BASE_URL=http://localhost:3000 -e TEST_EMAIL=user@test.com -e TEST_PASSWORD=pass script.js
+ */
+export const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+
+export const TEST_USER = {
+  email: __ENV.TEST_EMAIL || 'loadtest@eventhorizon.dev',
+  password: __ENV.TEST_PASSWORD || 'LoadTest@123',
+  firstName: 'Load',
+  lastName: 'Test',
+  organizationName: 'LoadTestOrg',
+};
+
+export const ADMIN_TOKEN = __ENV.ADMIN_TOKEN || 'test-admin-token';
+
+/** Sample trigger payload used across tests */
+export const TRIGGER_PAYLOAD = {
+  contractId: 'CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ',
+  eventName: 'transfer',
+  actionType: 'webhook',
+  actionUrl: 'https://webhook.site/test-load',
+  network: 'testnet',
+};

--- a/load-tests/k6/queue-load-test.js
+++ b/load-tests/k6/queue-load-test.js
@@ -1,0 +1,90 @@
+/**
+ * Queue & Batch endpoints load test
+ *
+ * Exercises: /api/queue/stats, /api/queue/jobs, /api/queue/batches/stats,
+ *            /api/queue/batches/flush, /api/queue/clean
+ *
+ * Run:
+ *   k6 run load-tests/k6/queue-load-test.js
+ */
+
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+import { BASE_URL, TEST_USER } from './config.js';
+
+const statsDuration = new Trend('queue_stats_duration', true);
+const jobsDuration  = new Trend('queue_jobs_duration',  true);
+const errorRate     = new Rate('error_rate');
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 200  },
+    { duration: '1m',  target: 2000 },
+    { duration: '1m',  target: 2000 },
+    { duration: '30s', target: 0    },
+  ],
+  thresholds: {
+    queue_stats_duration: ['p(95)<400'],
+    queue_jobs_duration:  ['p(95)<400'],
+    error_rate:           ['rate<0.01'],
+    http_req_failed:      ['rate<0.01'],
+  },
+};
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+function getToken() {
+  const email = `loadtest+${__VU}@eventhorizon.dev`;
+  http.post(
+    `${BASE_URL}/api/auth/register`,
+    JSON.stringify({ ...TEST_USER, email }),
+    { headers: JSON_HEADERS },
+  );
+  const res = http.post(
+    `${BASE_URL}/api/auth/login`,
+    JSON.stringify({ email, password: TEST_USER.password }),
+    { headers: JSON_HEADERS },
+  );
+  try { return JSON.parse(res.body).token || ''; } catch { return ''; }
+}
+
+// Acceptable statuses: 200 (Redis up) or 503 (Redis not configured)
+const queueOk = (r) => r.status === 200 || r.status === 503;
+
+export default function () {
+  const token = getToken();
+  const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
+
+  group('queue stats', () => {
+    const res = http.get(`${BASE_URL}/api/queue/stats`, { headers });
+    statsDuration.add(res.timings.duration);
+    const ok = check(res, { 'stats ok': queueOk });
+    errorRate.add(!ok);
+  });
+
+  group('queue jobs', () => {
+    for (const status of ['waiting', 'active', 'completed', 'failed']) {
+      const res = http.get(`${BASE_URL}/api/queue/jobs?status=${status}&limit=20`, { headers });
+      jobsDuration.add(res.timings.duration);
+      const ok = check(res, { [`jobs ${status} ok`]: queueOk });
+      errorRate.add(!ok);
+    }
+  });
+
+  group('batch stats', () => {
+    const res = http.get(`${BASE_URL}/api/queue/batches/stats`, { headers });
+    const ok = check(res, { 'batch stats ok': queueOk });
+    errorRate.add(!ok);
+  });
+
+  // Flush batches (write operation – lower frequency)
+  if (__ITER % 10 === 0) {
+    group('batch flush', () => {
+      const res = http.post(`${BASE_URL}/api/queue/batches/flush`, null, { headers });
+      check(res, { 'batch flush ok': queueOk });
+    });
+  }
+
+  sleep(1);
+}

--- a/load-tests/k6/smoke-test.js
+++ b/load-tests/k6/smoke-test.js
@@ -1,0 +1,75 @@
+/**
+ * Smoke test – runs on every PR in CI.
+ *
+ * Low VU count, short duration. Validates that the API is functional
+ * and meets the performance budget before a PR can be merged.
+ *
+ * Run:
+ *   k6 run load-tests/k6/smoke-test.js
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate } from 'k6/metrics';
+import { SMOKE_OPTIONS } from './thresholds.js';
+import { BASE_URL, TEST_USER, TRIGGER_PAYLOAD } from './config.js';
+
+const errorRate = new Rate('error_rate');
+
+export const options = SMOKE_OPTIONS;
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+export function setup() {
+  http.post(
+    `${BASE_URL}/api/auth/register`,
+    JSON.stringify(TEST_USER),
+    { headers: JSON_HEADERS },
+  );
+  const res = http.post(
+    `${BASE_URL}/api/auth/login`,
+    JSON.stringify({ email: TEST_USER.email, password: TEST_USER.password }),
+    { headers: JSON_HEADERS },
+  );
+  try { return { token: JSON.parse(res.body).token || '' }; } catch { return { token: '' }; }
+}
+
+export default function (data) {
+  const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${data.token}` };
+
+  // Health
+  const health = http.get(`${BASE_URL}/api/health`);
+  errorRate.add(!check(health, { 'health 200': (r) => r.status === 200 }));
+
+  // Auth
+  const login = http.post(
+    `${BASE_URL}/api/auth/login`,
+    JSON.stringify({ email: TEST_USER.email, password: TEST_USER.password }),
+    { headers: JSON_HEADERS },
+  );
+  errorRate.add(!check(login, { 'login 200': (r) => r.status === 200 }));
+
+  // Trigger create + delete
+  const create = http.post(
+    `${BASE_URL}/api/triggers`,
+    JSON.stringify(TRIGGER_PAYLOAD),
+    { headers },
+  );
+  const created = check(create, { 'trigger create 201': (r) => r.status === 201 });
+  errorRate.add(!created);
+
+  if (created) {
+    let id;
+    try { id = JSON.parse(create.body)._id; } catch { /* noop */ }
+    if (id) {
+      const del = http.del(`${BASE_URL}/api/triggers/${id}`, null, { headers });
+      errorRate.add(!check(del, { 'trigger delete 204': (r) => r.status === 204 }));
+    }
+  }
+
+  // Queue stats (503 acceptable when Redis is absent)
+  const stats = http.get(`${BASE_URL}/api/queue/stats`, { headers });
+  errorRate.add(!check(stats, { 'queue stats ok': (r) => r.status === 200 || r.status === 503 }));
+
+  sleep(1);
+}

--- a/load-tests/k6/stress-test.js
+++ b/load-tests/k6/stress-test.js
@@ -1,0 +1,217 @@
+/**
+ * EventHorizon API Stress Test
+ *
+ * Covers: auth, triggers CRUD, queue, discovery, and health endpoints.
+ * Simulates 5 000 concurrent virtual users ramping up over 2 minutes.
+ *
+ * Run:
+ *   k6 run load-tests/k6/stress-test.js
+ *
+ * With InfluxDB output:
+ *   k6 run --out influxdb=http://localhost:8086/k6 load-tests/k6/stress-test.js
+ */
+
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Trend, Rate, Counter } from 'k6/metrics';
+import { BASE_URL, TEST_USER, TRIGGER_PAYLOAD } from './config.js';
+
+// ---------------------------------------------------------------------------
+// Custom metrics
+// ---------------------------------------------------------------------------
+const authDuration    = new Trend('auth_duration',    true);
+const triggerDuration = new Trend('trigger_duration', true);
+const queueDuration   = new Trend('queue_duration',   true);
+const errorRate       = new Rate('error_rate');
+const triggerCreated  = new Counter('triggers_created');
+
+// ---------------------------------------------------------------------------
+// Load profile – ramp to 5 000 VUs, sustain, then ramp down
+// ---------------------------------------------------------------------------
+export const options = {
+  stages: [
+    { duration: '30s',  target: 100  },   // warm-up
+    { duration: '1m',   target: 1000 },   // ramp-up
+    { duration: '2m',   target: 5000 },   // peak load
+    { duration: '1m',   target: 5000 },   // sustain peak
+    { duration: '30s',  target: 0    },   // ramp-down
+  ],
+  thresholds: {
+    // Import thresholds from thresholds.js so they stay in sync with PR gates
+    http_req_duration:        ['p(95)<500', 'p(99)<1000'],
+    http_req_failed:          ['rate<0.01'],
+    error_rate:               ['rate<0.01'],
+    auth_duration:            ['p(95)<300'],
+    trigger_duration:         ['p(95)<500'],
+    queue_duration:           ['p(95)<400'],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+function authHeaders(token) {
+  return { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
+}
+
+/**
+ * Register + login and return a JWT access token.
+ * Registration may fail with 409 (user already exists) – that is fine.
+ */
+function authenticate() {
+  // Attempt registration (idempotent – ignore 409)
+  http.post(
+    `${BASE_URL}/api/auth/register`,
+    JSON.stringify({
+      ...TEST_USER,
+      // Make email unique per VU to avoid conflicts during ramp-up
+      email: `loadtest+${__VU}@eventhorizon.dev`,
+    }),
+    { headers: JSON_HEADERS },
+  );
+
+  const loginRes = http.post(
+    `${BASE_URL}/api/auth/login`,
+    JSON.stringify({ email: `loadtest+${__VU}@eventhorizon.dev`, password: TEST_USER.password }),
+    { headers: JSON_HEADERS },
+  );
+
+  authDuration.add(loginRes.timings.duration);
+
+  const ok = check(loginRes, {
+    'login status 200': (r) => r.status === 200,
+    'login has token':  (r) => {
+      try { return !!JSON.parse(r.body).token; } catch { return false; }
+    },
+  });
+
+  errorRate.add(!ok);
+
+  try {
+    return JSON.parse(loginRes.body).token || '';
+  } catch {
+    return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup – runs once before the test
+// ---------------------------------------------------------------------------
+export function setup() {
+  // Ensure at least one user exists for the test
+  http.post(
+    `${BASE_URL}/api/auth/register`,
+    JSON.stringify(TEST_USER),
+    { headers: JSON_HEADERS },
+  );
+  const loginRes = http.post(
+    `${BASE_URL}/api/auth/login`,
+    JSON.stringify({ email: TEST_USER.email, password: TEST_USER.password }),
+    { headers: JSON_HEADERS },
+  );
+  try {
+    return { token: JSON.parse(loginRes.body).token || '' };
+  } catch {
+    return { token: '' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default function – executed by every VU on every iteration
+// ---------------------------------------------------------------------------
+export default function (data) {
+  const token = authenticate();
+  const headers = authHeaders(token);
+
+  // ── Health check ──────────────────────────────────────────────────────────
+  group('health', () => {
+    const res = http.get(`${BASE_URL}/api/health`);
+    check(res, { 'health 200': (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+  });
+
+  sleep(0.1);
+
+  // ── Triggers CRUD ─────────────────────────────────────────────────────────
+  let triggerId;
+  group('triggers', () => {
+    // Create
+    const createRes = http.post(
+      `${BASE_URL}/api/triggers`,
+      JSON.stringify(TRIGGER_PAYLOAD),
+      { headers },
+    );
+    triggerDuration.add(createRes.timings.duration);
+    const created = check(createRes, {
+      'trigger create 201': (r) => r.status === 201,
+    });
+    errorRate.add(!created);
+
+    if (created) {
+      triggerCreated.add(1);
+      try { triggerId = JSON.parse(createRes.body)._id; } catch { /* noop */ }
+    }
+
+    // List
+    const listRes = http.get(`${BASE_URL}/api/triggers`, { headers });
+    triggerDuration.add(listRes.timings.duration);
+    check(listRes, { 'trigger list 200': (r) => r.status === 200 });
+    errorRate.add(listRes.status !== 200);
+
+    if (triggerId) {
+      // Update
+      const updateRes = http.put(
+        `${BASE_URL}/api/triggers/${triggerId}`,
+        JSON.stringify({ ...TRIGGER_PAYLOAD, eventName: 'swap' }),
+        { headers },
+      );
+      triggerDuration.add(updateRes.timings.duration);
+      check(updateRes, { 'trigger update 200': (r) => r.status === 200 });
+      errorRate.add(updateRes.status !== 200);
+
+      // Versions
+      const versionsRes = http.get(`${BASE_URL}/api/triggers/${triggerId}/versions`, { headers });
+      check(versionsRes, { 'trigger versions 200': (r) => r.status === 200 });
+
+      // Delete
+      const deleteRes = http.del(`${BASE_URL}/api/triggers/${triggerId}`, null, { headers });
+      check(deleteRes, { 'trigger delete 204': (r) => r.status === 204 });
+      errorRate.add(deleteRes.status !== 204);
+    }
+  });
+
+  sleep(0.1);
+
+  // ── Queue endpoints ───────────────────────────────────────────────────────
+  group('queue', () => {
+    const statsRes = http.get(`${BASE_URL}/api/queue/stats`, { headers });
+    queueDuration.add(statsRes.timings.duration);
+    // 200 = Redis available, 503 = Redis not configured (both acceptable)
+    check(statsRes, { 'queue stats ok': (r) => r.status === 200 || r.status === 503 });
+
+    const jobsRes = http.get(`${BASE_URL}/api/queue/jobs?status=failed&limit=10`, { headers });
+    queueDuration.add(jobsRes.timings.duration);
+    check(jobsRes, { 'queue jobs ok': (r) => r.status === 200 || r.status === 503 });
+
+    const batchRes = http.get(`${BASE_URL}/api/queue/batches/stats`, { headers });
+    queueDuration.add(batchRes.timings.duration);
+    check(batchRes, { 'batch stats ok': (r) => r.status === 200 || r.status === 503 });
+  });
+
+  sleep(0.1);
+
+  // ── Discovery ─────────────────────────────────────────────────────────────
+  group('discovery', () => {
+    const res = http.post(
+      `${BASE_URL}/api/discovery/assign-poller`,
+      JSON.stringify({ eventType: 'transfer', network: 'testnet' }),
+      { headers },
+    );
+    // 200 = poller assigned, 503 = Consul not available (both acceptable in CI)
+    check(res, { 'discovery ok': (r) => r.status === 200 || r.status === 503 || r.status === 404 });
+  });
+
+  sleep(0.5);
+}

--- a/load-tests/k6/thresholds.js
+++ b/load-tests/k6/thresholds.js
@@ -1,0 +1,82 @@
+/**
+ * EventHorizon Performance Budget
+ *
+ * Import this file into any k6 script to apply the standard PR thresholds:
+ *
+ *   import { THRESHOLDS } from './thresholds.js';
+ *   export const options = { thresholds: THRESHOLDS, stages: [...] };
+ *
+ * These values are the acceptance gates for every pull request.
+ * A PR that causes any threshold to be breached MUST NOT be merged.
+ *
+ * Threshold reference:
+ *   https://k6.io/docs/using-k6/thresholds/
+ */
+
+/**
+ * Standard performance budget applied to all PR load tests.
+ *
+ * Metric                  | Budget          | Rationale
+ * ----------------------- | --------------- | ------------------------------------------
+ * http_req_duration p(95) | < 500 ms        | 95 % of requests must be fast
+ * http_req_duration p(99) | < 1 000 ms      | Tail latency cap
+ * http_req_failed         | < 1 %           | Error rate cap
+ * http_req_duration avg   | < 200 ms        | Average response time
+ * auth_duration p(95)     | < 300 ms        | Auth endpoints must be snappy
+ * trigger_duration p(95)  | < 500 ms        | Trigger CRUD latency cap
+ * queue_duration p(95)    | < 400 ms        | Queue read latency cap
+ * error_rate              | < 1 %           | Custom error counter cap
+ */
+export const THRESHOLDS = {
+  // Global HTTP metrics
+  http_req_duration: ['p(95)<500', 'p(99)<1000', 'avg<200'],
+  http_req_failed:   ['rate<0.01'],
+
+  // Custom per-feature metrics (defined in individual test scripts)
+  auth_duration:    ['p(95)<300'],
+  trigger_duration: ['p(95)<500'],
+  queue_duration:   ['p(95)<400'],
+  error_rate:       ['rate<0.01'],
+};
+
+/**
+ * Smoke-test options – used in CI on every PR to catch regressions quickly.
+ * Low VU count, short duration, strict thresholds.
+ */
+export const SMOKE_OPTIONS = {
+  vus:      10,
+  duration: '30s',
+  thresholds: THRESHOLDS,
+};
+
+/**
+ * Soak-test options – run nightly to detect memory leaks and slow degradation.
+ */
+export const SOAK_OPTIONS = {
+  stages: [
+    { duration: '5m',  target: 500  },
+    { duration: '30m', target: 500  },
+    { duration: '5m',  target: 0    },
+  ],
+  thresholds: {
+    ...THRESHOLDS,
+    // Slightly relaxed for long-running soak
+    http_req_duration: ['p(95)<800', 'p(99)<1500'],
+  },
+};
+
+/**
+ * Spike-test options – validates behaviour under sudden traffic bursts.
+ */
+export const SPIKE_OPTIONS = {
+  stages: [
+    { duration: '10s', target: 100  },
+    { duration: '1m',  target: 5000 },  // sudden spike
+    { duration: '10s', target: 100  },
+    { duration: '30s', target: 0    },
+  ],
+  thresholds: {
+    http_req_failed: ['rate<0.05'],   // allow slightly higher error rate during spike
+    error_rate:      ['rate<0.05'],
+  },
+};

--- a/load-tests/k6/triggers-load-test.js
+++ b/load-tests/k6/triggers-load-test.js
@@ -1,0 +1,132 @@
+/**
+ * Triggers CRUD load test
+ *
+ * Exercises the full trigger lifecycle: create → list → update → versions → restore → delete.
+ * Designed to simulate 5 000+ concurrent event trigger operations.
+ *
+ * Run:
+ *   k6 run load-tests/k6/triggers-load-test.js
+ */
+
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Trend, Rate, Counter } from 'k6/metrics';
+import { BASE_URL, TEST_USER, TRIGGER_PAYLOAD } from './config.js';
+
+const createDuration  = new Trend('trigger_create_duration',  true);
+const listDuration    = new Trend('trigger_list_duration',    true);
+const updateDuration  = new Trend('trigger_update_duration',  true);
+const deleteDuration  = new Trend('trigger_delete_duration',  true);
+const errorRate       = new Rate('error_rate');
+const triggersCreated = new Counter('triggers_created_total');
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 500  },
+    { duration: '2m',  target: 5000 },
+    { duration: '1m',  target: 5000 },
+    { duration: '30s', target: 0    },
+  ],
+  thresholds: {
+    trigger_create_duration: ['p(95)<600'],
+    trigger_list_duration:   ['p(95)<400'],
+    trigger_update_duration: ['p(95)<600'],
+    trigger_delete_duration: ['p(95)<400'],
+    error_rate:              ['rate<0.01'],
+    http_req_failed:         ['rate<0.01'],
+  },
+};
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+function getToken() {
+  const email = `loadtest+${__VU}@eventhorizon.dev`;
+  http.post(
+    `${BASE_URL}/api/auth/register`,
+    JSON.stringify({ ...TEST_USER, email }),
+    { headers: JSON_HEADERS },
+  );
+  const res = http.post(
+    `${BASE_URL}/api/auth/login`,
+    JSON.stringify({ email, password: TEST_USER.password }),
+    { headers: JSON_HEADERS },
+  );
+  try { return JSON.parse(res.body).token || ''; } catch { return ''; }
+}
+
+export default function () {
+  const token = getToken();
+  const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
+
+  let triggerId;
+
+  // ── Create ────────────────────────────────────────────────────────────────
+  group('create trigger', () => {
+    const res = http.post(
+      `${BASE_URL}/api/triggers`,
+      JSON.stringify(TRIGGER_PAYLOAD),
+      { headers },
+    );
+    createDuration.add(res.timings.duration);
+    const ok = check(res, { 'create 201': (r) => r.status === 201 });
+    errorRate.add(!ok);
+    if (ok) {
+      triggersCreated.add(1);
+      try { triggerId = JSON.parse(res.body)._id; } catch { /* noop */ }
+    }
+  });
+
+  // ── List ──────────────────────────────────────────────────────────────────
+  group('list triggers', () => {
+    const res = http.get(`${BASE_URL}/api/triggers`, { headers });
+    listDuration.add(res.timings.duration);
+    const ok = check(res, {
+      'list 200':        (r) => r.status === 200,
+      'list is array':   (r) => { try { return Array.isArray(JSON.parse(r.body)); } catch { return false; } },
+    });
+    errorRate.add(!ok);
+  });
+
+  if (!triggerId) { sleep(1); return; }
+
+  // ── Update ────────────────────────────────────────────────────────────────
+  group('update trigger', () => {
+    const res = http.put(
+      `${BASE_URL}/api/triggers/${triggerId}`,
+      JSON.stringify({ ...TRIGGER_PAYLOAD, eventName: `swap_${__ITER}` }),
+      { headers },
+    );
+    updateDuration.add(res.timings.duration);
+    const ok = check(res, { 'update 200': (r) => r.status === 200 });
+    errorRate.add(!ok);
+  });
+
+  // ── Versions ──────────────────────────────────────────────────────────────
+  group('trigger versions', () => {
+    const res = http.get(`${BASE_URL}/api/triggers/${triggerId}/versions`, { headers });
+    check(res, { 'versions 200': (r) => r.status === 200 });
+
+    // Restore version 1 if it exists
+    let versions;
+    try { versions = JSON.parse(res.body); } catch { versions = []; }
+    if (Array.isArray(versions) && versions.length > 0) {
+      const v = versions[0].version || 1;
+      const restoreRes = http.post(
+        `${BASE_URL}/api/triggers/${triggerId}/versions/${v}/restore`,
+        null,
+        { headers },
+      );
+      check(restoreRes, { 'restore 200': (r) => r.status === 200 });
+    }
+  });
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+  group('delete trigger', () => {
+    const res = http.del(`${BASE_URL}/api/triggers/${triggerId}`, null, { headers });
+    deleteDuration.add(res.timings.duration);
+    const ok = check(res, { 'delete 204': (r) => r.status === 204 });
+    errorRate.add(!ok);
+  });
+
+  sleep(0.5);
+}


### PR DESCRIPTION
pr closes #247 

- Add k6 stress test scripts covering all API endpoints (auth, triggers CRUD, queue, discovery) with 5k+ concurrent VU support
- Add performance budget thresholds.js as single source of truth for PR gates (p95 < 500ms, error rate < 1%)
- Add smoke-test.js for CI integration on every PR
- Add Docker Compose stack for InfluxDB + Grafana with auto-provisioned datasource and 8-panel dashboard
- Add docs/load-testing.md with setup, usage, and CI guide

Closes #274